### PR TITLE
Refactor tests

### DIFF
--- a/tests/App/AppKernel.php
+++ b/tests/App/AppKernel.php
@@ -17,7 +17,7 @@ use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\HttpKernel\Kernel;
 
-class AppKernel extends Kernel
+abstract class AppKernel extends Kernel
 {
     public function registerBundles(): array
     {

--- a/tests/App/config.yml
+++ b/tests/App/config.yml
@@ -31,10 +31,6 @@ monolog:
 liip_test_fixtures: ~
 
 doctrine:
-    dbal:
-        driver: pdo_sqlite
-        path: "%kernel.cache_dir%/test.db"
-        charset: UTF8
     orm:
         default_entity_manager: default
         entity_managers:

--- a/tests/AppConfigPhpcr/AppConfigPhpcrKernel.php
+++ b/tests/AppConfigPhpcr/AppConfigPhpcrKernel.php
@@ -13,10 +13,10 @@ declare(strict_types=1);
 
 namespace Liip\Acme\Tests\AppConfigPhpcr;
 
-use Liip\Acme\Tests\App\AppKernel;
+use Liip\Acme\Tests\AppConfigSqlite\AppConfigSqliteKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
-class AppConfigPhpcrKernel extends AppKernel
+class AppConfigPhpcrKernel extends AppConfigSqliteKernel
 {
     public function registerBundles(): array
     {

--- a/tests/AppConfigSqlite/AppConfigSqliteKernel.php
+++ b/tests/AppConfigSqlite/AppConfigSqliteKernel.php
@@ -11,12 +11,12 @@ declare(strict_types=1);
  * with this source code in the file LICENSE.
  */
 
-namespace Liip\Acme\Tests\AppConfig;
+namespace Liip\Acme\Tests\AppConfigSqlite;
 
-use Liip\Acme\Tests\AppConfigSqlite\AppConfigSqliteKernel;
+use Liip\Acme\Tests\App\AppKernel;
 use Symfony\Component\Config\Loader\LoaderInterface;
 
-class AppConfigKernel extends AppConfigSqliteKernel
+class AppConfigSqliteKernel extends AppKernel
 {
     /**
      * Load the config.yml from the current directory.
@@ -26,7 +26,7 @@ class AppConfigKernel extends AppConfigSqliteKernel
         // Load the default file.
         parent::registerContainerConfiguration($loader);
 
-        // Load the file with "liip_test_fixtures" parameters
+        // Load the file with SQLite configuration
         $loader->load(__DIR__.'/config.yml');
     }
 }

--- a/tests/AppConfigSqlite/config.yml
+++ b/tests/AppConfigSqlite/config.yml
@@ -1,0 +1,7 @@
+# inherits configuration from ../App/config.yml
+
+doctrine:
+    dbal:
+        driver: pdo_sqlite
+        path: "%kernel.cache_dir%/test.db"
+        charset: UTF8

--- a/tests/Test/WebTestCaseTest.php
+++ b/tests/Test/WebTestCaseTest.php
@@ -15,7 +15,7 @@ namespace Liip\Acme\Tests\Test;
 
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
-use Liip\Acme\Tests\App\AppKernel;
+use Liip\Acme\Tests\AppConfigSqlite\AppConfigSqliteKernel;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
 
@@ -29,12 +29,12 @@ class WebTestCaseTest extends WebTestCase
 
     public function setUp(): void
     {
-        static::$class = AppKernel::class;
+        static::$class = AppConfigSqliteKernel::class;
     }
 
     public static function getKernelClass()
     {
-        return AppKernel::class;
+        return AppConfigSqliteKernel::class;
     }
 
     public function testLoadEmptyFixtures(): void


### PR DESCRIPTION
The default configuration contained SQLite configuration, so the AppKernel that run tests with MySQL configuration also had the configuration of SQLite, I saw this when dumping the Doctrine parameters.