### PR TITLE
Remove dependency on WebTestCase

### DIFF
--- a/doc/database.md
+++ b/doc/database.md
@@ -8,7 +8,7 @@ DoctrineFixturesBundle installed and configured first:
 In case tests require database access make sure that the database is created and
 proxies are generated.  For tests that rely on specific database contents,
 write fixture classes and call `loadFixtures()` method from the bundled
-`Test\WebTestCase` class. This will replace the database configured in
+`Test\FixturesTrait` class. This will replace the database configured in
 `config_test.yml` with the specified fixtures. Please note that `loadFixtures()`
 will delete the contents from the database before loading the fixtures. That's
 why you should use a designated database for tests.
@@ -200,7 +200,7 @@ Tips for Fixture Loading Tests
 
 ### Loading Fixtures Using Alice
 If you would like to setup your fixtures with yml files using [Alice](https://github.com/nelmio/alice),
-[`Liip\TestFixturesBundle\Test\WebTestCase`](Test/WebTestCase.php) has a helper function `loadFixtureFiles`
+[`Liip\TestFixturesBundle\Test\FixturesTrait`](../src/Test/FixturesTrait.php) has a helper function `loadFixtureFiles`
 which takes an array of resources, or paths to yml files, and returns an array of objects.
 This method uses the [Theofidry AliceDataFixtures loader](https://github.com/theofidry/AliceDataFixtures#doctrine-orm)
 rather than the FunctionalTestBundle's load methods.

--- a/src/Services/DatabaseToolCollection.php
+++ b/src/Services/DatabaseToolCollection.php
@@ -15,7 +15,7 @@ use Doctrine\Common\Annotations\AnnotationReader;
 use Liip\TestFixturesBundle\Annotations\DisableDatabaseCache;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use Symfony\Bridge\Doctrine\ManagerRegistry;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -43,7 +43,7 @@ final class DatabaseToolCollection
         $this->items[$databaseTool->getType()][$databaseTool->getDriverName()] = $databaseTool;
     }
 
-    public function get($omName = null, $registryName = 'doctrine', int $purgeMode = null, WebTestCase $webTestCase): AbstractDatabaseTool
+    public function get($omName = null, $registryName = 'doctrine', int $purgeMode = null, KernelTestCase $testCase = null): AbstractDatabaseTool
     {
         /** @var ManagerRegistry $registry */
         $registry = $this->container->get($registryName);
@@ -56,7 +56,7 @@ final class DatabaseToolCollection
         $databaseTool->setRegistry($registry);
         $databaseTool->setObjectManagerName($omName);
         $databaseTool->setPurgeMode($purgeMode);
-        $databaseTool->setWebTestCase($webTestCase);
+        $databaseTool->setTestCase($testCase);
 
         $databaseTool->setDatabaseCacheEnabled($this->isCacheEnabled());
 

--- a/src/Services/DatabaseTools/AbstractDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDatabaseTool.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Persistence\ObjectManager;
 use Doctrine\DBAL\Connection;
 use Liip\TestFixturesBundle\Services\DatabaseBackup\DatabaseBackupInterface;
 use Liip\TestFixturesBundle\Services\FixturesLoaderFactory;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -57,9 +57,9 @@ abstract class AbstractDatabaseTool
     protected $purgeMode;
 
     /**
-     * @var WebTestCase
+     * @var KernelTestCase
      */
-    protected $webTestCase;
+    protected $testCase;
 
     /**
      * @var bool
@@ -101,9 +101,9 @@ abstract class AbstractDatabaseTool
         $this->purgeMode = $purgeMode;
     }
 
-    public function setWebTestCase(WebTestCase $webTestCase): void
+    public function setTestCase(KernelTestCase $testCase): void
     {
-        $this->webTestCase = $webTestCase;
+        $this->testCase = $testCase;
     }
 
     abstract public function getType(): string;

--- a/src/Services/DatabaseTools/MongoDBDatabaseTool.php
+++ b/src/Services/DatabaseTools/MongoDBDatabaseTool.php
@@ -71,11 +71,11 @@ class MongoDBDatabaseTool extends AbstractDatabaseTool
                 $this->om->flush();
                 $this->om->clear();
 
-                $this->webTestCase->preFixtureBackupRestore($this->om, $referenceRepository, $backupService->getBackupFilePath());
+                $this->testCase->preFixtureBackupRestore($this->om, $referenceRepository, $backupService->getBackupFilePath());
                 $executor = $this->getExecutor($this->getPurger());
                 $executor->setReferenceRepository($referenceRepository);
                 $backupService->restore($executor);
-                $this->webTestCase->postFixtureBackupRestore($backupService->getBackupFilePath());
+                $this->testCase->postFixtureBackupRestore($backupService->getBackupFilePath());
 
                 return $executor;
             }
@@ -91,9 +91,9 @@ class MongoDBDatabaseTool extends AbstractDatabaseTool
         $executor->execute($loader->getFixtures(), true);
 
         if ($backupService) {
-            $this->webTestCase->preReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
+            $this->testCase->preReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
             $backupService->backup($executor);
-            $this->webTestCase->postReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
+            $this->testCase->postReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
         }
 
         return $executor;

--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -108,11 +108,11 @@ class ORMDatabaseTool extends AbstractDatabaseTool
                 $this->om->flush();
                 $this->om->clear();
 
-                $this->webTestCase->preFixtureBackupRestore($this->om, $referenceRepository, $backupService->getBackupFilePath());
+                $this->testCase->preFixtureBackupRestore($this->om, $referenceRepository, $backupService->getBackupFilePath());
                 $executor = $this->getExecutor($this->getPurger());
                 $executor->setReferenceRepository($referenceRepository);
                 $backupService->restore($executor, $this->excludedDoctrineTables);
-                $this->webTestCase->postFixtureBackupRestore($backupService->getBackupFilePath());
+                $this->testCase->postFixtureBackupRestore($backupService->getBackupFilePath());
 
                 return $executor;
             }
@@ -134,7 +134,7 @@ class ORMDatabaseTool extends AbstractDatabaseTool
             }
         }
 
-        $this->webTestCase->postFixtureSetup();
+        $this->testCase->postFixtureSetup();
 
         $executor = $this->getExecutor($this->getPurger());
         $executor->setReferenceRepository($referenceRepository);
@@ -148,9 +148,9 @@ class ORMDatabaseTool extends AbstractDatabaseTool
         $executor->execute($loader->getFixtures(), true);
 
         if ($backupService) {
-            $this->webTestCase->preReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
+            $this->testCase->preReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
             $backupService->backup($executor);
-            $this->webTestCase->postReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
+            $this->testCase->postReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
         }
 
         return $executor;

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -46,11 +46,11 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
                 $this->om->flush();
                 $this->om->clear();
 
-                $this->webTestCase->preFixtureBackupRestore($this->om, $referenceRepository, $backupService->getBackupFilePath());
+                $this->testCase->preFixtureBackupRestore($this->om, $referenceRepository, $backupService->getBackupFilePath());
                 $executor = $this->getExecutor($this->getPurger());
                 $executor->setReferenceRepository($referenceRepository);
                 $backupService->restore($executor);
-                $this->webTestCase->postFixtureBackupRestore($backupService->getBackupFilePath());
+                $this->testCase->postFixtureBackupRestore($backupService->getBackupFilePath());
 
                 return $executor;
             }
@@ -64,7 +64,7 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
                 $schemaTool->createSchema($this->getMetadatas());
             }
         }
-        $this->webTestCase->postFixtureSetup();
+        $this->testCase->postFixtureSetup();
 
         $executor = $this->getExecutor($this->getPurger());
         $executor->setReferenceRepository($referenceRepository);
@@ -76,9 +76,9 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
         $executor->execute($loader->getFixtures(), true);
 
         if ($backupService) {
-            $this->webTestCase->preReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
+            $this->testCase->preReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
             $backupService->backup($executor);
-            $this->webTestCase->postReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
+            $this->testCase->postReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
         }
 
         return $executor;

--- a/src/Services/DatabaseTools/PHPCRDatabaseTool.php
+++ b/src/Services/DatabaseTools/PHPCRDatabaseTool.php
@@ -74,11 +74,11 @@ class PHPCRDatabaseTool extends AbstractDatabaseTool
                 $this->om->flush();
                 $this->om->clear();
 
-                $this->webTestCase->preFixtureBackupRestore($this->om, $referenceRepository, $backupService->getBackupFilePath());
+                $this->testCase->preFixtureBackupRestore($this->om, $referenceRepository, $backupService->getBackupFilePath());
                 $executor = $this->getExecutor($this->getPurger());
                 $executor->setReferenceRepository($referenceRepository);
                 $backupService->restore($executor);
-                $this->webTestCase->postFixtureBackupRestore($backupService->getBackupFilePath());
+                $this->testCase->postFixtureBackupRestore($backupService->getBackupFilePath());
 
                 return $executor;
             }
@@ -94,9 +94,9 @@ class PHPCRDatabaseTool extends AbstractDatabaseTool
         $executor->execute($loader->getFixtures(), true);
 
         if ($backupService) {
-            $this->webTestCase->preReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
+            $this->testCase->preReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
             $backupService->backup($executor);
-            $this->webTestCase->postReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
+            $this->testCase->postReferenceSave($this->om, $executor, $backupService->getBackupFilePath());
         }
 
         return $executor;

--- a/tests/Test/ConfigMysqlCacheDbTest.php
+++ b/tests/Test/ConfigMysqlCacheDbTest.php
@@ -34,7 +34,7 @@ use Liip\Acme\Tests\AppConfigMysqlCacheDb\AppConfigMysqlKernelCacheDb;
  * @preserveGlobalState disabled
  * @IgnoreAnnotation("group")
  */
-class WebTestCaseConfigMysqlCacheDbTest extends WebTestCaseConfigMysqlTest
+class ConfigMysqlCacheDbTest extends ConfigMysqlTest
 {
     protected static function getKernelClass(): string
     {

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Liip\Acme\Tests\AppConfigMysql\AppConfigMysqlKernel;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
  * Test MySQL database.
@@ -37,7 +37,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
  * @preserveGlobalState disabled
  * @IgnoreAnnotation("group")
  */
-class WebTestCaseConfigMysqlTest extends WebTestCase
+class ConfigMysqlTest extends KernelTestCase
 {
     use FixturesTrait;
 

--- a/tests/Test/ConfigMysqlUrlTest.php
+++ b/tests/Test/ConfigMysqlUrlTest.php
@@ -32,7 +32,7 @@ use Liip\Acme\Tests\AppConfigMysqlUrl\AppConfigMysqlUrlKernel;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-class WebTestCaseConfigMysqlUrlTest extends WebTestCaseConfigMysqlTest
+class ConfigMysqlUrlTest extends ConfigMysqlTest
 {
     protected static function getKernelClass(): string
     {

--- a/tests/Test/ConfigPhpcrTest.php
+++ b/tests/Test/ConfigPhpcrTest.php
@@ -18,7 +18,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 use Liip\Acme\Tests\AppConfigPhpcr\AppConfigPhpcrKernel;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 use Symfony\Component\Console\Tester\CommandTester;
 
 /**
@@ -31,7 +31,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-class WebTestCaseConfigPhpcrTest extends WebTestCase
+class ConfigPhpcrTest extends KernelTestCase
 {
     use FixturesTrait;
 

--- a/tests/Test/ConfigSqlitetTest.php
+++ b/tests/Test/ConfigSqlitetTest.php
@@ -17,13 +17,13 @@ use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Liip\Acme\Tests\AppConfigSqlite\AppConfigSqliteKernel;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
  * @IgnoreAnnotation("depends")
  * @IgnoreAnnotation("expectedException")
  */
-class WebTestCaseTest extends WebTestCase
+class ConfigSqlitetTest extends KernelTestCase
 {
     use FixturesTrait;
 

--- a/tests/Test/ConfigTest.php
+++ b/tests/Test/ConfigTest.php
@@ -17,7 +17,7 @@ use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Liip\Acme\Tests\AppConfig\AppConfigKernel;
 use Liip\TestFixturesBundle\Annotations\DisableDatabaseCache;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
  * Tests that configuration has been loaded and users can be logged in.
@@ -34,7 +34,7 @@ use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
  *
  * @IgnoreAnnotation("expectedException")
  */
-class WebTestCaseConfigTest extends WebTestCase
+class ConfigTest extends KernelTestCase
 {
     use FixturesTrait;
 

--- a/tests/Test/WebTestCaseConfigPgsqlTest.php
+++ b/tests/Test/WebTestCaseConfigPgsqlTest.php
@@ -33,7 +33,7 @@ use Liip\TestFixturesBundle\Test\FixturesTrait;
  * @runTestsInSeparateProcesses
  * @preserveGlobalState disabled
  */
-class WebTestCaseConfigPgsqlTest extends WebTestCaseConfigMysqlTest
+class WebTestCaseConfigPgsqlTest extends ConfigMysqlTest
 {
     use FixturesTrait;
 


### PR DESCRIPTION
This dependency prevents defining a test class that inherits from `KernelTestCase`.

We don't need to inherit from `WebTestCase`, for example when testing a command.

`Symfony\Bundle\FrameworkBundle\Test\WebTestCase` inherits from `use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase` so it should not break existing tests.