### PR TITLE
Fix purge mode type hint

### DIFF
--- a/src/Services/DatabaseToolCollection.php
+++ b/src/Services/DatabaseToolCollection.php
@@ -43,7 +43,7 @@ final class DatabaseToolCollection
         $this->items[$databaseTool->getType()][$databaseTool->getDriverName()] = $databaseTool;
     }
 
-    public function get($omName = null, $registryName = 'doctrine', $purgeMode = null, WebTestCase $webTestCase): AbstractDatabaseTool
+    public function get($omName = null, $registryName = 'doctrine', int $purgeMode = null, WebTestCase $webTestCase): AbstractDatabaseTool
     {
         /** @var ManagerRegistry $registry */
         $registry = $this->container->get($registryName);

--- a/src/Services/DatabaseTools/AbstractDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDatabaseTool.php
@@ -52,7 +52,7 @@ abstract class AbstractDatabaseTool
     protected $connection;
 
     /**
-     * @var string
+     * @var int
      */
     protected $purgeMode;
 
@@ -96,7 +96,7 @@ abstract class AbstractDatabaseTool
         $this->connection = $this->registry->getConnection($omName);
     }
 
-    public function setPurgeMode(string $purgeMode = null): void
+    public function setPurgeMode(int $purgeMode = null): void
     {
         $this->purgeMode = $purgeMode;
     }


### PR DESCRIPTION
These constants are numbers, not strings: https://github.com/doctrine/data-fixtures/blob/v1.3.2/lib/Doctrine/Common/DataFixtures/Purger/ORMPurger.php#L22