### PR TITLE
Disable FOREIGN_KEY_CHECKS when purging database

### DIFF
--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -145,7 +145,9 @@ class ORMDatabaseTool extends AbstractDatabaseTool
         $executor = $this->getExecutor($this->getPurger());
         $executor->setReferenceRepository($referenceRepository);
         if (false === $append) {
+            $this->om->getConnection()->executeUpdate('SET FOREIGN_KEY_CHECKS = 0;');
             $executor->purge();
+            $this->om->getConnection()->executeUpdate('SET FOREIGN_KEY_CHECKS = 1;');
         }
 
         $loader = $this->fixturesLoaderFactory->getFixtureLoader($classNames);


### PR DESCRIPTION
When the parameter `liip_test_fixtures.keep_database_and_schema: true` is enabled, I have the following output:

> SQLSTATE[23000]: Integrity constraint violation: 1451 Cannot delete or update a parent row: a foreign key constraint fails (`truebadges`.`Badge`, CONSTRAINT `FK_3F316719F6BD1646` FOREIGN KEY (`site_id`) REFERENCES `Site` (`id`))
> 
> …/vendor/doctrine/dbal/lib/Doctrine/DBAL/Driver/AbstractMySQLDriver.php:49
> …/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:169
> …/vendor/doctrine/dbal/lib/Doctrine/DBAL/DBALException.php:145
> …/vendor/doctrine/dbal/lib/Doctrine/DBAL/Connection.php:1063
> …/doctrine/data-fixtures/lib/Doctrine/Common/DataFixtures> /Purger/ORMPurger.php:132
> …/vendor/doctrine/data-fixtures/lib/Doctrine/Common/DataFixtures/Executor/AbstractExecutor.php:133
> …/vendor/liip/test-fixtures-bundle/src/Services/DatabaseTools/ORMDatabaseTool.php:148
> …/vendor/liip/test-fixtures-bundle/src/Test/FixturesTrait.php:87
> …/tests/SEBundle/Command/CalculateSitesMinMaxCommandTest.php:33

This PR disables `FOREIGN_KEY_CHECKS` before purging the database.