### PR TITLE
Remove dependency symfony/browser-kit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,6 @@
     "require": {
         "php": "^7.1",
         "doctrine/common": "^2.0",
-        "symfony/browser-kit": "^3.4 || ^4.1",
         "symfony/framework-bundle": "^3.4 || ^4.1"
     },
     "require-dev": {


### PR DESCRIPTION
I was surprised to see that requiring this bundle added the browser-kit.