### PR TITLE
Add missing type hint in FixturesTrait

### DIFF
--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -76,12 +76,6 @@ trait FixturesTrait
      * Depends on the doctrine data-fixtures library being available in the
      * class path.
      *
-     * @param array  $classNames   List of fully qualified class names of fixtures to load
-     * @param bool   $append
-     * @param string $omName       The name of object manager to use
-     * @param string $registryName The service id of manager registry to use
-     * @param int    $purgeMode    Sets the ORM purge mode
-     *
      * @return null|AbstractExecutor
      */
     protected function loadFixtures(array $classNames = [], bool $append = false, ?string $omName = null, string $registryName = 'doctrine', ?int $purgeMode = null): ?AbstractExecutor
@@ -95,18 +89,7 @@ trait FixturesTrait
         return $dbTool->loadFixtures($classNames, $append);
     }
 
-    /**
-     * @param array  $paths        Either symfony resource locators (@ BundleName/etc) or actual file paths
-     * @param bool   $append
-     * @param null   $omName
-     * @param string $registryName
-     * @param int    $purgeMode
-     *
-     * @throws \BadMethodCallException
-     *
-     * @return array
-     */
-    public function loadFixtureFiles(array $paths = [], bool $append = false, ?string $omName = null, $registryName = 'doctrine', ?int $purgeMode = null)
+    public function loadFixtureFiles(array $paths = [], bool $append = false, ?string $omName = null, $registryName = 'doctrine', ?int $purgeMode = null): array
     {
         /** @var ContainerInterface $container */
         $container = $this->getContainer();

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -75,8 +75,6 @@ trait FixturesTrait
      *
      * Depends on the doctrine data-fixtures library being available in the
      * class path.
-     *
-     * @return null|AbstractExecutor
      */
     protected function loadFixtures(array $classNames = [], bool $append = false, ?string $omName = null, string $registryName = 'doctrine', ?int $purgeMode = null): ?AbstractExecutor
     {

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -75,6 +75,14 @@ trait FixturesTrait
      *
      * Depends on the doctrine data-fixtures library being available in the
      * class path.
+     *
+     * @param array  $classNames   List of fully qualified class names of fixtures to load
+     * @param bool   $append
+     * @param string $omName       The name of object manager to use
+     * @param string $registryName The service id of manager registry to use
+     * @param int    $purgeMode    Sets the ORM purge mode
+     *
+     * @return null|AbstractExecutor
      */
     protected function loadFixtures(array $classNames = [], bool $append = false, ?string $omName = null, string $registryName = 'doctrine', ?int $purgeMode = null): ?AbstractExecutor
     {
@@ -87,6 +95,17 @@ trait FixturesTrait
         return $dbTool->loadFixtures($classNames, $append);
     }
 
+    /**
+     * @param array  $paths        Either symfony resource locators (@ BundleName/etc) or actual file paths
+     * @param bool   $append
+     * @param null   $omName
+     * @param string $registryName
+     * @param int    $purgeMode
+     *
+     * @throws \BadMethodCallException
+     *
+     * @return array
+     */
     public function loadFixtureFiles(array $paths = [], bool $append = false, ?string $omName = null, $registryName = 'doctrine', ?int $purgeMode = null)
     {
         /** @var ContainerInterface $container */


### PR DESCRIPTION
In LiipFunctionalTestBundle 2.x `WebTestCase::loadFixtureFiles` has a declared return type, see [here](https://github.com/liip/LiipFunctionalTestBundle/blob/7b4e40176c8a4fb359f28c27b1f71d33296a6aa9/src/Test/WebTestCase.php#L272)

```
    /**
     * ...
     *
     * @return array
     */
    public function loadFixtureFiles(array $paths = [], bool $append = false, ?string $omName = null, $registryName = 'doctrine', ?int $purgeMode = null)
    {
```

The FixturesTrait is missing this doc block which causes tools like [Psalm](http://psalm.dev) every time the return value of this function is used. For example upgrading to LiipFunctionalTestBundle 3.x and LiipTsetFixturesBundle cause me to get 943 errors in Psalm :joy:.

I added a PHP return type instead of hinting it with a doc block because the `$dbtool` has a declared return type so that shouldn't cause any issues.