### PR TITLE
Don't install monolog/monolog 2 for development

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/orm": "^2.6",
         "jackalope/jackalope-doctrine-dbal": "^1.3",
+        "monolog/monolog": "~1.11",
         "phpunit/phpunit": "^7.5 || ^8.0",
         "symfony/monolog-bundle": "^3.2",
         "symfony/phpunit-bridge": "^3.4 || ^4.1",


### PR DESCRIPTION
Fix error from CI:

> RuntimeException: Symfony 5 is required for Monolog 2 support. Please downgrade Monolog to version 1.

Source: https://travis-ci.com/liip/LiipTestFixturesBundle/jobs/256227739