### PR TITLE
Add parameter to disable metadata cache

### DIFF
--- a/src/DependencyInjection/Configuration.php
+++ b/src/DependencyInjection/Configuration.php
@@ -47,6 +47,7 @@ class Configuration implements ConfigurationInterface
                     ->end()
                 ->end()
             ->booleanNode('keep_database_and_schema')->defaultFalse()->end()
+            ->booleanNode('cache_metadata')->defaultTrue()->end()
         ;
 
         return $treeBuilder;

--- a/src/Services/DatabaseTools/AbstractDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDatabaseTool.php
@@ -26,6 +26,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 abstract class AbstractDatabaseTool
 {
     const KEEP_DATABASE_AND_SCHEMA_PARAMETER_NAME = 'liip_test_fixtures.keep_database_and_schema';
+    const CACHE_METADATA_PARAMETER_NAME = 'liip_test_fixtures.cache_metadata';
 
     protected $container;
 
@@ -186,6 +187,10 @@ abstract class AbstractDatabaseTool
 
     protected function getMetadatas(): array
     {
+        if(!$this->getCacheMetadataParameter()) {
+            return $this->om->getMetadataFactory()->getAllMetadata();
+        }
+
         $key = $this->getDriverName().$this->getType().$this->omName;
 
         if (!isset(self::$cachedMetadatas[$key])) {
@@ -207,5 +212,11 @@ abstract class AbstractDatabaseTool
     {
         return $this->container->hasParameter(self::KEEP_DATABASE_AND_SCHEMA_PARAMETER_NAME)
             && true === $this->container->getParameter(self::KEEP_DATABASE_AND_SCHEMA_PARAMETER_NAME);
+    }
+
+    protected function getCacheMetadataParameter()
+    {
+        return $this->container->hasParameter(self::CACHE_METADATA_PARAMETER_NAME)
+            && false !== $this->container->getParameter(self::CACHE_METADATA_PARAMETER_NAME);
     }
 }


### PR DESCRIPTION
I have tests which run with different kernels, each kernel having a separate set of entities. The database tool currently caches the metadata in between tests, which caused the changes to go undetected. 

This adds a parameter to disable the metadata cache so it is correctly reloaded between tests.
