### PR TITLE
Fixing doc

### DIFF
--- a/doc/database.md
+++ b/doc/database.md
@@ -166,9 +166,8 @@ Tips for Fixture Loading Tests
             public function testIndex()
             {
                 $this->loadFixtures(array(
-                    'Me\MyBundle\DataFixtures\ORM\LoadAnotherObjectData',
-                    true
-                ));
+                    'Me\MyBundle\DataFixtures\ORM\LoadAnotherObjectData'
+                ), true);
                 // ...
             }
         }


### PR DESCRIPTION
There is a mistake in doc. If you want to append a fixture, you should pass second argument instead of adding an element to array