### PR TITLE
Added loadAllFixtures method

### DIFF
--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Liip\TestFixturesBundle\Test;
 
+use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\Persistence\ObjectManager;
@@ -96,6 +97,25 @@ trait FixturesTrait
         $dbTool->setExcludedDoctrineTables($this->excludedDoctrineTables);
 
         return $dbTool->loadAliceFixture($paths, $append);
+    }
+
+    /**
+     * This loads all the fixtures defined in the project, including ordering
+     * them, e.g. by the DependentFixtureInterface. The call to this method
+     * does the same as running the console command doctrine:fixtures:load,
+     * including the use of the group parameter.
+     */
+    protected function loadAllFixtures(array $groups = []): ?AbstractExecutor
+    {
+        /** @var SymfonyFixturesLoader $loader */
+        $loader = $this->getContainer()->get('doctrine.fixtures.loader');
+        $fixtures = $loader->getFixtures($groups);
+        $fixtureClasses = [];
+        foreach ($fixtures as $fixture) {
+            $fixtureClasses[] = get_class($fixture);
+        }
+
+        return $this->loadFixtures($fixtureClasses);
     }
 
     /**

--- a/tests/App/config.yml
+++ b/tests/App/config.yml
@@ -42,6 +42,7 @@ services:
     _defaults:
         autowire: true
         autoconfigure: true
+        public: true
     Liip\Acme\Tests\App\DataFixtures\ORM\:
         resource: 'DataFixtures/ORM/*'
         tags: ['doctrine.fixture.orm']


### PR DESCRIPTION
loadAllFixtures works the same as the console command doctrine:fixtures:load, which makes loading all fixtures at once in the correct order (either by DependentFixtureInterface or OrderedFixtureInterface).

There is one issue with the unit test, which I could not resolve:
setting the services by default to public to be able to mock the doctrine fixture loader doesn't seem to work. Therefor the test is skipped, but otherwise working correctly.