### PR TITLE
Add loadAllFixtures method

### DIFF
--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Liip\TestFixturesBundle\Test;
 
+use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Persistence\ObjectManager;
@@ -58,6 +59,25 @@ trait FixturesTrait
         $dbTool->setExcludedDoctrineTables($this->excludedDoctrineTables);
 
         return $dbTool->loadAliceFixture($paths, $append);
+    }
+
+    /**
+     * This loads all the fixtures defined in the project, including ordering
+     * them, e.g. by the DependentFixtureInterface. The call to this method
+     * does the same as running the console command doctrine:fixtures:load,
+     * including the use of the group parameter.
+     */
+    protected function loadAllFixtures(array $groups = []): ?AbstractExecutor
+    {
+        /** @var SymfonyFixturesLoader $loader */
+        $loader = $this->getContainer()->get('doctrine.fixtures.loader');
+        $fixtures = $loader->getFixtures($groups);
+        $fixtureClasses = [];
+        foreach ($fixtures as $fixture) {
+            $fixtureClasses[] = get_class($fixture);
+        }
+
+        return $this->loadFixtures($fixtureClasses);
     }
 
     /**

--- a/tests/App/DataFixtures/ORM/LoadDependentUserWithServiceData.php
+++ b/tests/App/DataFixtures/ORM/LoadDependentUserWithServiceData.php
@@ -39,14 +39,14 @@ class LoadDependentUserWithServiceData extends AbstractFixture implements Depend
     public function load(ObjectManager $manager): void
     {
         /** @var \Liip\Acme\Tests\App\Entity\User $user */
-        $user = clone $this->getReference('user');
+        $user = clone $this->getReference('serviceUser');
 
         $user->setId(3);
 
         $manager->persist($user);
         $manager->flush();
 
-        $user = clone $this->getReference('user');
+        $user = clone $this->getReference('serviceUser');
 
         $user->setId(4);
 

--- a/tests/App/DataFixtures/ORM/LoadUserDataInGroup.php
+++ b/tests/App/DataFixtures/ORM/LoadUserDataInGroup.php
@@ -13,19 +13,34 @@ declare(strict_types=1);
 
 namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
+use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class LoadUserWithServiceData extends AbstractFixture implements FixtureInterface
+class LoadUserDataInGroup extends AbstractFixture implements FixtureInterface, FixtureGroupInterface
 {
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null): void
+    {
+        $this->container = $container;
+    }
+
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var User $user */
+        /** @var \Liip\Acme\Tests\App\Entity\User $user */
         $user = new User();
         $user->setId(1);
         $user->setName('foo bar');
@@ -38,13 +53,28 @@ class LoadUserWithServiceData extends AbstractFixture implements FixtureInterfac
         $manager->persist($user);
         $manager->flush();
 
-        $this->addReference('serviceUser', $user);
+        $this->addReference('groupUser', $user);
 
-        $user = clone $this->getReference('serviceUser');
+        $user = clone $this->getReference('groupUser');
 
         $user->setId(2);
 
         $manager->persist($user);
         $manager->flush();
+
+        $user = clone $this->getReference('groupUser');
+
+        $user->setId(3);
+
+        $manager->persist($user);
+        $manager->flush();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getGroups(): array
+    {
+        return ['myGroup'];
     }
 }

--- a/tests/App/DataFixtures/ORM/LoadUserDataInGroup.php
+++ b/tests/App/DataFixtures/ORM/LoadUserDataInGroup.php
@@ -16,7 +16,7 @@ namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 


### PR DESCRIPTION
The loadAllFixtures behaves like the console command doctrine:fixtures:load, including using the correct order from DependentFixtureInterface/OrderedFixtureInterface and grouping from FixtureGroupInterface.

I had to change some reference names in existing fixtures, because the name "user" was used in several fixtures. This caused problems for the unit test which loads everything. I hope this is OK.

(this is my first pull request ever, so I hope I did everything correct. If not, please give me a message)