### PR TITLE
Prevent duplicate kernels booting and ensure they're cleaned up

### DIFF
--- a/doc/database.md
+++ b/doc/database.md
@@ -92,6 +92,10 @@ Tips for Fixture Loading Tests
 
         public function testIndex()
         {
+            // If you need a client, you must create it before loading fixtures because
+            // creating the client boots the kernel, which is used by loadFixtures
+            $client = $this->createClient();
+    
             // add all your fixtures classes that implement
             // Doctrine\Common\DataFixtures\FixtureInterface
             $this->loadFixtures(array(
@@ -100,7 +104,6 @@ Tips for Fixture Loading Tests
             ));
 
             // you can now run your functional tests with a populated database
-            $client = $this->createClient();
             // ...
         }
     }
@@ -120,10 +123,12 @@ Tips for Fixture Loading Tests
 
         public function testIndex()
         {
+            // If you need a client, you must create it before loading fixtures because
+            // creating the client boots the kernel, which is used by loadFixtures
+            $client = $this->createClient();
             $this->loadFixtures();
 
             // you can now run your functional tests with a populated database
-            $client = $this->createClient();
             // ...
         }
     }
@@ -190,9 +195,10 @@ Tips for Fixture Loading Tests
                 'Me\MyBundle\DataFixtures\MongoDB\LoadData'
             );
 
-            $this->loadFixtures($fixtures, false, null, 'doctrine_mongodb');
-
+            // If you need a client, you must create it before loading fixtures because
+            // creating the client boots the kernel, which is used by loadFixtures
             $client = $this->createClient();
+            $this->loadFixtures($fixtures, false, null, 'doctrine_mongodb');
         }
     }
     ```

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -36,9 +36,11 @@ class ExampleFunctionalTest extends WebTestCase
      */
     public function testUserFooIndex(): void
     {
+        // If you need a client, you must create it before loading fixtures because
+        // creating the client boots the kernel, which is used by loadFixtures
+        $client = $this->createClient();
         $this->loadFixtures(['Liip\FooBundle\Tests\Fixtures\LoadUserData']);
 
-        $client = $this->createClient();
         $crawler = $client->request('GET', '/users/foo');
         
         // …

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -47,12 +47,7 @@ trait FixturesTrait
             ];
             $kernel = $this->bootKernel($options);
 
-            $container = $kernel->getContainer();
-            if ($container->has('test.service_container')) {
-                $this->containers[$environment] = $container->get('test.service_container');
-            } else {
-                $this->containers[$environment] = $container;
-            }
+            $this->containers[$environment] = static::$container;
         }
 
         return $this->containers[$environment];

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -45,8 +45,7 @@ trait FixturesTrait
             $options = [
                 'environment' => $environment,
             ];
-            $kernel = $this->createKernel($options);
-            $kernel->boot();
+            $kernel = $this->bootKernel($options);
 
             $container = $kernel->getContainer();
             if ($container->has('test.service_container')) {

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -33,9 +33,6 @@ trait FixturesTrait
      */
     private $excludedDoctrineTables = [];
 
-    /** @var bool */
-    private $kernelBooted = false;
-
     /**
      * Get an instance of the dependency injection container.
      * (this creates a kernel *without* parameters).
@@ -49,7 +46,8 @@ trait FixturesTrait
                 'environment' => $environment,
             ];
 
-            if (false === $this->kernelBooted) {
+            // Check that the kernel has not been booted separately (eg. with static::createClient())
+            if (null === static::$kernel || null === static::$kernel->getContainer()) {
                 $this->bootKernel($options);
             }
 
@@ -160,7 +158,6 @@ trait FixturesTrait
         }
 
         $this->containers = null;
-        $this->kernelBooted = false;
 
         parent::tearDown();
     }

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -47,13 +47,16 @@ trait FixturesTrait
             ];
 
             // Check that the kernel has not been booted separately (eg. with static::createClient())
-            $kernel = static::$kernel;
-            if (null === $kernel) {
-                $kernel = $this->bootKernel($options);
+            if (null === static::$kernel) {
+                $this->bootKernel($options);
             }
 
-            // bootKernel() has logic to ensure static::$container is the correct container
-            $this->containers[$environment] = static::$container;
+            $container = static::$kernel->getContainer();
+            if ($container->has('test.service_container')) {
+                $this->containers[$environment] = $container->get('test.service_container');
+            } else {
+                $this->containers[$environment] = $container;
+            }
         }
 
         return $this->containers[$environment];

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -33,6 +33,9 @@ trait FixturesTrait
      */
     private $excludedDoctrineTables = [];
 
+    /** @var bool */
+    private $kernelBooted = false;
+
     /**
      * Get an instance of the dependency injection container.
      * (this creates a kernel *without* parameters).
@@ -46,8 +49,7 @@ trait FixturesTrait
                 'environment' => $environment,
             ];
 
-            // Check that the kernel has not been booted separately (eg. with static::createClient())
-            if (null === static::$kernel) {
+            if (false === $this->kernelBooted) {
                 $this->bootKernel($options);
             }
 
@@ -158,6 +160,7 @@ trait FixturesTrait
         }
 
         $this->containers = null;
+        $this->kernelBooted = false;
 
         parent::tearDown();
     }

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -45,7 +45,10 @@ trait FixturesTrait
             $options = [
                 'environment' => $environment,
             ];
-            $kernel = $this->bootKernel($options);
+            $kernel = static::$kernel;
+            if (null === $kernel) {
+                $kernel = $this->bootKernel($options);
+            }
 
             $this->containers[$environment] = static::$container;
         }

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -45,11 +45,14 @@ trait FixturesTrait
             $options = [
                 'environment' => $environment,
             ];
+
+            // Check that the kernel has not been booted separately (eg. with static::createClient())
             $kernel = static::$kernel;
             if (null === $kernel) {
                 $kernel = $this->bootKernel($options);
             }
 
+            // bootKernel() has logic to ensure static::$container is the correct container
             $this->containers[$environment] = static::$container;
         }
 


### PR DESCRIPTION
After upgrading to Symfony 4.4 we received a massive memory blow out when running tests, taking our memory using from `300MB` to `9GB`. I initially reported an issue to Symfony (symfony/symfony#35164) and after many months and a lot of debugging I identified symfony/symfony#34078 as the pull request which make the memory leak apparent.

There are a few smaller issues which come together to create the memory leak:
* As of Symfony 4.4+ they no longer reset the test container after tests, instead only resetting the real one
* Symfony KernelTestCase boots and keeps track of it's own kernel
* LiipTestFixtures creates and keeps track of another kernel, separate to Symfony
* Symfony WebTestCase::createClient() will always boot a kernel and booting a kernel before calling this function is deprecated in Symfony 4.4 (symfony/symfony#32056)
* Loading fixtures with LiipTestFixtures boots it's own kernel, regardless of whether it's called before or after WebTestCase::createClient()

To fix this we need to ensure only the kernel tracked by Symfony KernelTestCase is booted, because it will be automatically cleaned up by Symfony. If we want to run multiple kernels, we need to ensure previous ones are shut down before booting new ones (symfony/symfony#34507).

I had a quick look through old issues in LiipTestFixturesBundle and LiipFunctionalTestBundle and I believe that liip/LiipFunctionalTestBundle#152 and #12 will be fixed by this PR.

I'm unsure how to test this change (is testing necessary here?), if someone can point me in the right direction that would be appreciated.