### PR TITLE
Allow database to be kept when loading fixtures but still purged

### DIFF
--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -25,7 +25,7 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
         return 'pdo_sqlite';
     }
 
-    public function loadFixtures(array $classNames = [], bool $append = false): AbstractExecutor
+    public function loadFixtures(array $classNames = [], bool $append = false, $dropDb = true): AbstractExecutor
     {
         $referenceRepository = new ProxyReferenceRepository($this->om);
         $cacheDriver = $this->om->getMetadataFactory()->getCacheDriver();
@@ -56,7 +56,7 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
             }
         }
 
-        if (false === $append) {
+        if (false === $append && true === $dropDb) {
             // TODO: handle case when using persistent connections. Fail loudly?
             $schemaTool = new SchemaTool($this->om);
             $schemaTool->dropDatabase();

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -25,7 +25,7 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
         return 'pdo_sqlite';
     }
 
-    public function loadFixtures(array $classNames = [], bool $append = false, $dropDb = true): AbstractExecutor
+    public function loadFixtures(array $classNames = [], bool $append = false): AbstractExecutor
     {
         $referenceRepository = new ProxyReferenceRepository($this->om);
         $cacheDriver = $this->om->getMetadataFactory()->getCacheDriver();
@@ -56,7 +56,7 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
             }
         }
 
-        if (false === $append && true === $dropDb) {
+        if (false === $append && false === $this->getKeepDatabaseAndSchemaParameter()) {
             // TODO: handle case when using persistent connections. Fail loudly?
             $schemaTool = new SchemaTool($this->om);
             $schemaTool->dropDatabase();


### PR DESCRIPTION
Allow a custom database to be used and not dropped when loading fixtures with sqlite databases.
The default functionality is maintained where the database will be dropped but a dropDb variable has been added to override this functionality.

Fixes https://github.com/liip/LiipFunctionalTestBundle/issues/566