### PR TITLE
Override enable/disable foregin key checks for sqlite

### DIFF
--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -163,7 +163,7 @@ class ORMDatabaseTool extends AbstractDatabaseTool
         return $executor;
     }
 
-    private function disableForeignKeyChecksIfApplicable(): void
+    protected function disableForeignKeyChecksIfApplicable(): void
     {
         if (!$this->isMysql()) {
             return;
@@ -178,7 +178,7 @@ class ORMDatabaseTool extends AbstractDatabaseTool
         $this->shouldEnableForeignKeyChecks = true;
     }
 
-    private function enableForeignKeyChecksIfApplicable(): void
+    protected function enableForeignKeyChecksIfApplicable(): void
     {
         if (!$this->isMysql()) {
             return;


### PR DESCRIPTION
As specified in #68, the ORMDatabaseTool will enable and disable foreign key checks when loading fixtures for MySQL, but for other databases the foreign key checks are not enabled or disabled.

With Sqlite, it's possible to manually enable foreign key checks with `PRAGMA foreign_keys = 1`, which will then cause foreign key violation exceptions when loading fixtures.

Enabling foreign key checks in Sqlite is fairly common, especially if you run Sqlite in your test environment and MySQL in a production environment. An example for how they would be enabled in a Symfony application can be seen in [this SO question](https://stackoverflow.com/q/43356717/1393498).

This change allows the ORMSqliteDatabaseTool to enable and disable foreign key checks in Sqlite if they were manually enabled previously.

Closes: #68 