### PR TITLE
Add compatibility with `doctrine/common` ^3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: xenial
 
 language: php
 
@@ -6,8 +6,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
-
-sudo: false
+  - 7.4
 
 cache:
   directories:
@@ -24,20 +23,18 @@ matrix:
     - php: 7.1
       env: COMPOSER_FLAGS="--prefer-lowest"
     - php: 7.2
-      env: SYMFONY_VERSION="3.4.*"
+      env: SYMFONY_VERSION="^3.4"
     - php: 7.2
       env: SYMFONY_VERSION="^4.1"
     - php: 7.2
-      env: EXTRA_PACKAGES="doctrine/phpcr-bundle:^1.3 doctrine/phpcr-odm:^1.3"
+      env: EXTRA_PACKAGES="doctrine/phpcr-bundle:^2.0 doctrine/phpcr-odm:^1.3 jackalope/jackalope-doctrine-dbal:^1.5"
     - php: 7.3
       env: SYMFONY_VERSION="^4.1"
     - php: 7.3 
       env: SYMFONY_VERSION="^5.0" 
   allow_failures:
     - php: 7.2
-      env: SYMFONY_VERSION="dev-master"
-    - php: 7.2
-      env: EXTRA_PACKAGES="doctrine/phpcr-bundle:^1.3 doctrine/phpcr-odm:^1.3"
+      env: EXTRA_PACKAGES="doctrine/phpcr-bundle:^2.0 doctrine/phpcr-odm:^1.3 jackalope/jackalope-doctrine-dbal:^1.5"
   fast_finish: true
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,15 @@
     ],
     "require": {
         "php": "^7.1",
-        "doctrine/common": "^2.0",
+        "doctrine/common": "^2.13 || ^3.0",
         "symfony/framework-bundle": "^3.4 || ^4.1 || ^5.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.3",
-        "doctrine/doctrine-bundle": "^1.8 | ^2.0",
+        "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/orm": "^2.6",
-        "monolog/monolog": "~1.11 | ^2.0",
+        "monolog/monolog": "~1.11 || ^2.0",
         "phpunit/phpunit": "^7.5 || ^8.0",
         "symfony/monolog-bundle": "^3.2",
         "symfony/monolog-bridge": ">=3",

--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "doctrine/doctrine-bundle": "^1.8 || ^2.0",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/orm": "^2.6",
-        "monolog/monolog": "~1.11 || ^2.0",
+        "monolog/monolog": "^1.11 || ^2.0",
         "phpunit/phpunit": "^7.5 || ^8.0",
-        "symfony/monolog-bundle": "^3.2",
         "symfony/monolog-bridge": ">=3",
+        "symfony/monolog-bundle": "^3.2",
         "symfony/phpunit-bridge": "^3.4 || ^4.1 || ^5.0",
         "theofidry/alice-data-fixtures": "^1.0.1"
     },

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,7 +3,7 @@
 <!-- https://phpunit.de/manual/3.7/en/appendixes.configuration.html -->
 <phpunit
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.5/phpunit.xsd"
+    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
     bootstrap="tests/App/bootstrap.php"
     colors="true"
     beStrictAboutOutputDuringTests="true"

--- a/src/Services/DatabaseTools/AbstractDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDatabaseTool.php
@@ -12,8 +12,8 @@
 namespace Liip\TestFixturesBundle\Services\DatabaseTools;
 
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
-use Doctrine\Common\Persistence\ManagerRegistry;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ManagerRegistry;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\DBAL\Connection;
 use Liip\TestFixturesBundle\Services\DatabaseBackup\DatabaseBackupInterface;
 use Liip\TestFixturesBundle\Services\FixturesLoaderFactory;

--- a/src/Test/FixturesTrait.php
+++ b/src/Test/FixturesTrait.php
@@ -15,7 +15,7 @@ namespace Liip\TestFixturesBundle\Test;
 
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\DependencyInjection\ResettableContainerInterface;
 

--- a/tests/App/DataFixtures/ORM/LoadDependentUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadDependentUserData.php
@@ -15,7 +15,7 @@ namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LoadDependentUserData extends AbstractFixture implements DependentFixtureInterface

--- a/tests/App/DataFixtures/ORM/LoadDependentUserWithServiceData.php
+++ b/tests/App/DataFixtures/ORM/LoadDependentUserWithServiceData.php
@@ -15,7 +15,7 @@ namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LoadDependentUserWithServiceData extends AbstractFixture implements DependentFixtureInterface

--- a/tests/App/DataFixtures/ORM/LoadSecondUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadSecondUserData.php
@@ -15,7 +15,7 @@ namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/App/DataFixtures/ORM/LoadUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserData.php
@@ -15,7 +15,7 @@ namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 

--- a/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
@@ -15,7 +15,7 @@ namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
 
 class LoadUserWithServiceData extends AbstractFixture implements FixtureInterface

--- a/tests/AppConfigPhpcr/DataFixtures/PHPCR/LoadTaskData.php
+++ b/tests/AppConfigPhpcr/DataFixtures/PHPCR/LoadTaskData.php
@@ -14,7 +14,7 @@ declare(strict_types=1);
 namespace Liip\Acme\Tests\AppConfigPhpcr\DataFixtures\PHPCR;
 
 use Doctrine\Common\DataFixtures\FixtureInterface;
-use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Persistence\ObjectManager;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Liip\Acme\Tests\AppConfigPhpcr\Document\Task;
 

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -19,6 +19,12 @@ use Liip\Acme\Tests\AppConfigMysql\AppConfigMysqlKernel;
 use Liip\TestFixturesBundle\Test\FixturesTrait;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
+// BC, needed by "theofidry/alice-data-fixtures: <1.3" not compatible with "doctrine/persistence: ^2.0"
+if (interface_exists('\Doctrine\Persistence\ObjectManager') &&
+    !interface_exists('\Doctrine\Common\Persistence\ObjectManager')) {
+    class_alias('\Doctrine\Persistence\ObjectManager', '\Doctrine\Common\Persistence\ObjectManager');
+}
+
 /**
  * Test MySQL database.
  *

--- a/tests/Test/ConfigSqliteTest.php
+++ b/tests/Test/ConfigSqliteTest.php
@@ -13,6 +13,12 @@ declare(strict_types=1);
 
 namespace Liip\Acme\Tests\Test;
 
+// BC, needed by "theofidry/alice-data-fixtures: <1.3" not compatible with "doctrine/persistence: ^2.0"
+if (interface_exists('\Doctrine\Persistence\ObjectManager') &&
+    !interface_exists('\Doctrine\Common\Persistence\ObjectManager')) {
+    class_alias('\Doctrine\Persistence\ObjectManager', '\Doctrine\Common\Persistence\ObjectManager');
+}
+
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Liip\Acme\Tests\AppConfigSqlite\AppConfigSqliteKernel;
@@ -23,7 +29,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  * @IgnoreAnnotation("depends")
  * @IgnoreAnnotation("expectedException")
  */
-class ConfigSqlitetTest extends KernelTestCase
+class ConfigSqliteTest extends KernelTestCase
 {
     use FixturesTrait;
 

--- a/tests/Test/ConfigTest.php
+++ b/tests/Test/ConfigTest.php
@@ -13,6 +13,12 @@ declare(strict_types=1);
 
 namespace Liip\Acme\Tests\Test;
 
+// BC, needed by "theofidry/alice-data-fixtures: <1.3" not compatible with "doctrine/persistence: ^2.0"
+if (interface_exists('\Doctrine\Persistence\ObjectManager') &&
+    !interface_exists('\Doctrine\Common\Persistence\ObjectManager')) {
+    class_alias('\Doctrine\Persistence\ObjectManager', '\Doctrine\Common\Persistence\ObjectManager');
+}
+
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Liip\Acme\Tests\AppConfig\AppConfigKernel;
 use Liip\TestFixturesBundle\Annotations\DisableDatabaseCache;


### PR DESCRIPTION
Add compatibility with `doctrine/common: ^3.0`.

Because it needs a patched version of `theofidry/alice-data-fixtures` also with `Doctrine/Common` namespace compatibility, I'm not sure if this PR can be merged as-is.

Fixes #69.