### PR TITLE
Do not store references as an unique static property in mysql backup

### DIFF
--- a/src/Services/DatabaseBackup/MysqlDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/MysqlDatabaseBackup.php
@@ -20,8 +20,6 @@ use Doctrine\ORM\Tools\SchemaTool;
  */
 final class MysqlDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
 {
-    protected static $referenceData;
-
     protected static $metadata;
 
     protected static $schemaUpdatedFlag = false;
@@ -43,11 +41,7 @@ final class MysqlDatabaseBackup extends AbstractDatabaseBackup implements Databa
 
     protected function getReferenceBackup(): string
     {
-        if (empty(self::$referenceData)) {
-            self::$referenceData = file_get_contents($this->getReferenceBackupFilePath());
-        }
-
-        return self::$referenceData;
+        return file_get_contents($this->getReferenceBackupFilePath());
     }
 
     public function isBackupActual(): bool

--- a/tests/App/DataFixtures/ORM/LoadSecondUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadSecondUserData.php
@@ -50,5 +50,7 @@ class LoadSecondUserData extends AbstractFixture implements FixtureInterface
 
         $manager->persist($user);
         $manager->flush();
+
+        $this->addReference('user-second', $user);
     }
 }

--- a/tests/Test/ConfigMysqlCacheDbTest.php
+++ b/tests/Test/ConfigMysqlCacheDbTest.php
@@ -119,4 +119,23 @@ class ConfigMysqlCacheDbTest extends ConfigMysqlTest
             $user1->getSalt()
         );
     }
+
+    /**
+     * @group mysql
+     */
+    public function testLoadFixturesCheckReferences(): void
+    {
+        $referenceRepository = $this->loadFixtures([
+            'Liip\Acme\Tests\App\DataFixtures\ORM\LoadUserData',
+        ])->getReferenceRepository();
+
+        $this->assertCount(1, $referenceRepository->getReferences());
+
+        $referenceRepository = $this->loadFixtures([
+            'Liip\Acme\Tests\App\DataFixtures\ORM\LoadUserData',
+            'Liip\Acme\Tests\App\DataFixtures\ORM\LoadSecondUserData',
+        ])->getReferenceRepository();
+
+        $this->assertCount(2, $referenceRepository->getReferences());
+    }
 }


### PR DESCRIPTION
The list of references were stored as a single property.

As a consequence, when loading different fixtures, some reference can be missing during runtime.

I do not see any time loss loading the reference file (issuing a `file_get_contents` is not be the slow part)