### PR TITLE
2.x: Add link to 1.x

### DIFF
--- a/doc/installation.md
+++ b/doc/installation.md
@@ -6,9 +6,12 @@ Installation
     Open a command console, enter your project directory and execute the
     following command to download the latest stable version of this bundle:
 
+    Use the next major version and help us find potential issues:
     ```bash
-    $ composer require --dev liip/test-fixtures-bundle:^2.0.0
+    $ composer require --dev liip/test-fixtures-bundle:^2.0.0-alpha1
     ```
+    
+    Or use the current stable version: see the [documentation for 1.x](https://github.com/liip/LiipTestFixturesBundle/blob/1.x/README.md).
 
     This command requires you to have Composer installed globally, as explained
     in the [installation chapter](https://getcomposer.org/doc/00-intro.md)


### PR DESCRIPTION
Suggest to users to use the 2.x while providing a path to use the current stable branch.