### PR TITLE
Reset change to accept php 7.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,13 +19,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['7.3', '7.4', '8.0']
+        php-version: ['7.2','7.3', '7.4', '8.0']
         composer-flags: ['']
         symfony-version: ['']
         include:
-          - php-version: 7.3
+          - php-version: 7.2
             composer-flags: "--prefer-lowest"
-          - php-version: 7.3
+          - php-version: 7.2
             symfony-version: "^4.4"
 
     services:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 composer.lock
 vendor
 .php_cs.cache

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.3 || ^8.0",
+        "php": "^7.2 || ^8.0",
         "doctrine/common": "^2.13 || ^3.0",
         "symfony/event-dispatcher": "^4.4 || ^5.0",
         "symfony/event-dispatcher-contracts": "^1 || ^2",


### PR DESCRIPTION
Since symfony 5.3, LiipTestFixture v1.1.x generate Fatal error see  #112.

Migrate to LiipTestFixture v2.x was the solution but the mininum php version requirement is php 7.3, howerver symfony 5.3 accept php 7.2.

This PR allow user to migrate/use to LiipTestFixturesBundle v2.x with symfony 5.x and php 7.2.x