### PR TITLE
Deprecated Doctrine\DBAL\Driver::getName()

### DIFF
--- a/src/Services/DatabaseToolCollection.php
+++ b/src/Services/DatabaseToolCollection.php
@@ -47,7 +47,7 @@ final class DatabaseToolCollection
     {
         /** @var ManagerRegistry $registry */
         $registry = $this->container->get($registryName);
-        $driverName = ('ORM' === $registry->getName()) ? $registry->getConnection()->getDriver()->getName() : 'default';
+        $driverName = ('ORM' === $registry->getName()) ? get_class($registry->getConnection()->getDriver()) : 'default';
 
         $databaseTool = isset($this->items[$registry->getName()][$driverName])
             ? $this->items[$registry->getName()][$driverName]


### PR DESCRIPTION
Provides a fix for #150 and allows usage with Doctrine DBAL 3 where Driver::getName()
has been deprecated.﻿

edit: I've spoke to soon, this is not the only blocking issue for DBAL 3.
