### PR TITLE
Deprecated Doctrine\DBAL\Driver::getName()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,6 +39,9 @@
         "symfony/phpunit-bridge": "^4.4 || ^5.0",
         "theofidry/alice-data-fixtures": "^1.0.1"
     },
+    "conflict": {
+        "doctrine/dbal": "<2.13"
+    },
     "suggest": {
         "doctrine/dbal": "Required when using the fixture loading functionality with an ORM and SQLite",
         "doctrine/doctrine-fixtures-bundle": "Required when using the fixture loading functionality",

--- a/src/Services/DatabaseToolCollection.php
+++ b/src/Services/DatabaseToolCollection.php
@@ -47,7 +47,7 @@ final class DatabaseToolCollection
     {
         /** @var ManagerRegistry $registry */
         $registry = $this->container->get($registryName);
-        $driverName = ('ORM' === $registry->getName()) ? get_class($registry->getConnection()->getDriver()) : 'default';
+        $driverName = ('ORM' === $registry->getName()) ? \get_class($registry->getConnection()->getDriver()) : 'default';
 
         $databaseTool = isset($this->items[$registry->getName()][$driverName])
             ? $this->items[$registry->getName()][$driverName]

--- a/src/Services/DatabaseToolCollection.php
+++ b/src/Services/DatabaseToolCollection.php
@@ -47,7 +47,7 @@ final class DatabaseToolCollection
     {
         /** @var ManagerRegistry $registry */
         $registry = $this->container->get($registryName);
-        $driverName = ('ORM' === $registry->getName()) ? $registry->getConnection()->getDriver()->getName() : 'default';
+        $driverName = ('ORM' === $registry->getName()) ? get_class($registry->getConnection()->getDriver()) : 'default';
 
         $databaseTool = isset($this->items[$registry->getName()][$driverName])
             ? $this->items[$registry->getName()][$driverName]

--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -182,7 +182,13 @@ class ORMDatabaseTool extends AbstractDatabaseTool
             return;
         }
 
-        $currentValue = $this->connection->fetchColumn('SELECT @@SESSION.foreign_key_checks');
+        // Doctrine DBAL 2.x deprecated fetchColumn() in favor of fetchOne()
+        if (\method_exists($this->connection, 'fetchColumn')) {
+            $currentValue = $this->connection->fetchColumn('SELECT @@SESSION.foreign_key_checks');
+        } else {
+            $currentValue = $this->connection->fetchOne('SELECT @@SESSION.foreign_key_checks');
+        }
+
         if ('0' === $currentValue) {
             return;
         }

--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -183,7 +183,7 @@ class ORMDatabaseTool extends AbstractDatabaseTool
         }
 
         // Doctrine DBAL 2.x deprecated fetchColumn() in favor of fetchOne()
-        if (\method_exists($this->connection, 'fetchColumn')) {
+        if (method_exists($this->connection, 'fetchColumn')) {
             $currentValue = $this->connection->fetchColumn('SELECT @@SESSION.foreign_key_checks');
         } else {
             $currentValue = $this->connection->fetchOne('SELECT @@SESSION.foreign_key_checks');

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -15,6 +15,7 @@ namespace Liip\TestFixturesBundle\Services\DatabaseTools;
 
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
+use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\ORM\Tools\SchemaTool;
 use Liip\TestFixturesBundle\Event\FixtureEvent;
@@ -35,7 +36,7 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
 
     public function getDriverName(): string
     {
-        return 'pdo_sqlite';
+        return Driver::class;
     }
 
     public function loadFixtures(array $classNames = [], bool $append = false): AbstractExecutor

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -114,7 +114,7 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
         }
 
         // Doctrine DBAL 2.x deprecated fetchColumn() in favor of fetchOne()
-        if (\method_exists($this->connection, 'fetchColumn')) {
+        if (method_exists($this->connection, 'fetchColumn')) {
             $currentValue = $this->connection->fetchColumn('PRAGMA foreign_keys');
         } else {
             $currentValue = $this->connection->fetchOne('PRAGMA foreign_keys');

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -113,7 +113,13 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
             return;
         }
 
-        $currentValue = $this->connection->fetchColumn('PRAGMA foreign_keys');
+        // Doctrine DBAL 2.x deprecated fetchColumn() in favor of fetchOne()
+        if (\method_exists($this->connection, 'fetchColumn')) {
+            $currentValue = $this->connection->fetchColumn('PRAGMA foreign_keys');
+        } else {
+            $currentValue = $this->connection->fetchOne('PRAGMA foreign_keys');
+        }
+
         if ('0' === $currentValue) {
             return;
         }


### PR DESCRIPTION
Use driver's class name since Driver::getName() has been removed in Doctrine DBAL 3.

Provides a fix for #150 and allows usage with Doctrine DBAL 3 where Driver::getName() has been deprecated.﻿