### PR TITLE
Feature/fix symfony deprecation in SymfonyFixturesLoaderWrapper

### DIFF
--- a/src/Services/SymfonyFixturesLoaderWrapper.php
+++ b/src/Services/SymfonyFixturesLoaderWrapper.php
@@ -30,6 +30,9 @@ final class SymfonyFixturesLoaderWrapper extends Loader
         $this->addFixture($this->symfonyFixturesLoader->getFixture($className));
     }
 
+    /**
+     * @return \Doctrine\Common\DataFixtures\FixtureInterface
+     */
     public function createFixture($class)
     {
         return $this->symfonyFixturesLoader->getFixture($class);

--- a/src/Services/SymfonyFixturesLoaderWrapper.php
+++ b/src/Services/SymfonyFixturesLoaderWrapper.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Liip\TestFixturesBundle\Services;
 
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
+use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\Loader;
 
 final class SymfonyFixturesLoaderWrapper extends Loader
@@ -30,10 +31,7 @@ final class SymfonyFixturesLoaderWrapper extends Loader
         $this->addFixture($this->symfonyFixturesLoader->getFixture($className));
     }
 
-    /**
-     * @return \Doctrine\Common\DataFixtures\FixtureInterface
-     */
-    public function createFixture($class)
+    public function createFixture($class): FixtureInterface
     {
         return $this->symfonyFixturesLoader->getFixture($class);
     }


### PR DESCRIPTION
Hi.
This will fix an symfony deprecation message.

`User Deprecated: Method "Doctrine\Common\DataFixtures\Loader::createFixture()" might add "FixtureInterface" as a native return type declaration in the future. Do the same in child class "Liip\TestFixturesBundle\Services\SymfonyFixturesLoaderWrapper" now to avoid errors or add an explicit @return annotation to suppress this message.`

Greetz