### PR TITLE
Allow Symfony 6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,6 +27,10 @@ jobs:
             composer-flags: "--prefer-lowest"
           - php-version: 7.2
             symfony-version: "^4.4"
+          - php-version: 8.0
+            symfony-version: "^6.0"
+          - php-version: 8.1
+            symfony-version: "^6.0"
 
     services:
       mysql:
@@ -75,12 +79,20 @@ jobs:
       - name: Require Symfony
         if: matrix.symfony-version != ''
         run: |
+          composer require --no-update symfony/flex:^1.17.3
           composer config extra.symfony.require "${{ matrix.symfony-version }}"
-          composer require --no-update symfony/flex symfony/framework-bundle=${{ matrix.symfony-version }}
+          composer require --no-update symfony/framework-bundle=${{ matrix.symfony-version }}
+
+      - name: Remove PHPCR with Symfony 6
+        if: matrix.symfony-version == '^6.0'
+        run: composer remove --no-update --dev doctrine/phpcr-bundle doctrine/phpcr-odm
 
       - name: Install Composer dependencies
         if: matrix.composer-flags == ''
         run: composer install
+
+      - name: Show Composer dependencies
+        run: composer show
 
       - name: Install Composer dependencies with options
         if: matrix.composer-flags != ''

--- a/UPGRADE-2.0.md
+++ b/UPGRADE-2.0.md
@@ -8,9 +8,9 @@ This is the list of actions that you need to take when upgrading this bundle fro
     - Use `loadAliceFixture(…)` instead of `loadFixtureFiles(…)`
     - `loadFixtures()` and `loadFixtureFiles()` only accept 2 arguments, here are the old arguments and the new way to use them:
       - 3rd argument `$omName`:
-        - call `self::$container->get(DatabaseToolCollection::class)->get($omName)` instead
+        - call `static::getContainer()->get(DatabaseToolCollection::class)->get($omName)` instead (or `self::$container->get(…)` with Symfony < 5.3)
       - 4th argument `$registryName`:
-        - call `self::$container->get(DatabaseToolCollection::class)->get(null, $registryName)` instead
+        - call `static::getContainer()->get(DatabaseToolCollection::class)->get(null, $registryName)` instead (or `self::$container->get(…)` with Symfony < 5.3)
       - 5th argument `$purgeMode`:
         - if you need to use that option only once: call `$databaseTool->withPurgeMode($purgeMode)->load…;`
         - if you need that option in all of your tests: call the setter `$databaseTool->setPurgeMode($purgeMode);` before loading fixtures
@@ -74,7 +74,7 @@ class ConfigTest extends KernelTestCase
 
         self::bootKernel();
 
-        $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
+        $this->databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
     }
     
     public function testLoadFixtures(): void

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "doctrine/common": "^2.13 || ^3.0",
-        "symfony/event-dispatcher": "^4.4 || ^5.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
         "symfony/event-dispatcher-contracts": "^1 || ^2",
-        "symfony/framework-bundle": "^4.4 || ^5.0",
-        "symfony/yaml": "^4.4 || ^5.0"
+        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.0 || ^6.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.3",
@@ -33,10 +33,10 @@
         "jackalope/jackalope-doctrine-dbal": "^1.5",
         "monolog/monolog": "^1.25.1 || ^2.0",
         "phpunit/phpunit": "^7.5 || ^8.0",
-        "symfony/doctrine-bridge": "^4.4 || ^5.0",
-        "symfony/monolog-bridge": "^4.4 || ^5.0",
+        "symfony/doctrine-bridge": "^4.4 || ^5.0 || ^6.0",
+        "symfony/monolog-bridge": "^4.4 || ^5.0 || ^6.0",
         "symfony/monolog-bundle": "^3.2",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0",
+        "symfony/phpunit-bridge": "^4.4 || ^5.0 || ^6.0",
         "theofidry/alice-data-fixtures": "^1.0.1"
     },
     "conflict": {

--- a/composer.json
+++ b/composer.json
@@ -17,10 +17,10 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "doctrine/common": "^2.13 || ^3.0",
-        "symfony/event-dispatcher": "^4.4 || ^5.0 || ^6.0",
+        "symfony/event-dispatcher": "^4.4 || ^5.4 || ^6.0",
         "symfony/event-dispatcher-contracts": "^1 || ^2",
-        "symfony/framework-bundle": "^4.4 || ^5.0 || ^6.0",
-        "symfony/yaml": "^4.4 || ^5.0 || ^6.0"
+        "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
+        "symfony/yaml": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.3",
@@ -33,10 +33,10 @@
         "jackalope/jackalope-doctrine-dbal": "^1.5",
         "monolog/monolog": "^1.25.1 || ^2.0",
         "phpunit/phpunit": "^7.5 || ^8.0",
-        "symfony/doctrine-bridge": "^4.4 || ^5.0 || ^6.0",
-        "symfony/monolog-bridge": "^4.4 || ^5.0 || ^6.0",
+        "symfony/doctrine-bridge": "^4.4 || ^5.4 || ^6.0",
+        "symfony/monolog-bridge": "^4.4 || ^5.4 || ^6.0",
         "symfony/monolog-bundle": "^3.2",
-        "symfony/phpunit-bridge": "^4.4 || ^5.0 || ^6.0",
+        "symfony/phpunit-bridge": "^4.4 || ^5.4 || ^6.0",
         "theofidry/alice-data-fixtures": "^1.0.1"
     },
     "conflict": {

--- a/doc/database.md
+++ b/doc/database.md
@@ -32,7 +32,9 @@ class MyControllerTest extends WebTestCase
     {
         parent::setUp();
 
-+        $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
++        $this->databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
++        // or with Symfony < 5.3
++        // $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
     }
 
     public function testIndex()
@@ -57,7 +59,7 @@ class MyControllerTest extends WebTestCase
 Methods
 -------
 
-`self::$container->get(DatabaseToolCollection::class)` has a method `get()` to load the default service, it also accepts several arguments:
+`static::getContainer()->get(DatabaseToolCollection::class)` has a method `get()` to load the default service, it also accepts several arguments:
 1. name of the object manager
 2. name of the registry, `doctrine` is the default value
 3. purge mode with `true` or `false`
@@ -155,7 +157,7 @@ class MyControllerTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
+        $this->databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
     }
 
     public function testIndex()
@@ -228,7 +230,7 @@ class MyControllerTest extends WebTestCase
     {
         // …
 
-        $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get('default', 'doctrine_phpcr');
+        $this->databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get('default', 'doctrine_phpcr');
     }
 }
 ```

--- a/doc/examples.md
+++ b/doc/examples.md
@@ -41,7 +41,7 @@ class ExampleFunctionalTest extends WebTestCase
     {
         parent::setUp();
 
-        $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
+        $this->databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get();
     }
 
     /**

--- a/tests/Test/ConfigEventsTest.php
+++ b/tests/Test/ConfigEventsTest.php
@@ -16,6 +16,7 @@ namespace Liip\Acme\Tests\Test;
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Liip\Acme\Tests\AppConfigEvents\AppConfigEventsKernel;
 use Liip\Acme\Tests\AppConfigEvents\EventListener\FixturesSubscriber;
+use Liip\Acme\Tests\Traits\ContainerProvider;
 use Liip\TestFixturesBundle\LiipTestFixturesEvents;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
@@ -36,6 +37,8 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  */
 class ConfigEventsTest extends KernelTestCase
 {
+    use ContainerProvider;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -49,7 +52,7 @@ class ConfigEventsTest extends KernelTestCase
      */
     public function testLoadEmptyFixturesAndCheckEvents(): void
     {
-        $databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
+        $databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
 
         $fixtures = $databaseTool->loadFixtures([]);
 
@@ -58,7 +61,7 @@ class ConfigEventsTest extends KernelTestCase
             $fixtures
         );
 
-        $eventDispatcher = self::$container->get('event_dispatcher');
+        $eventDispatcher = $this->getTestContainer()->get('event_dispatcher');
 
         $event = $eventDispatcher->getListeners(LiipTestFixturesEvents::PRE_FIXTURE_BACKUP_RESTORE);
         $this->assertSame('preFixtureBackupRestore', $event[0][1]);
@@ -86,7 +89,7 @@ class ConfigEventsTest extends KernelTestCase
     public function testLoadEmptyFixturesAndCheckEventsAreCalled(string $eventName, string $methodName, int $numberOfInvocations, bool $withCache = true): void
     {
         /** @var AbstractDatabaseTool $databaseTool */
-        $databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
+        $databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
 
         // Create the mock and declare that the method must be called (or not)
         $mock = $this->getMockBuilder(FixturesSubscriber::class)->getMock();
@@ -96,7 +99,7 @@ class ConfigEventsTest extends KernelTestCase
         ;
 
         // Register to the event
-        $eventDispatcher = self::$container->get('event_dispatcher');
+        $eventDispatcher = $this->getTestContainer()->get('event_dispatcher');
         $eventDispatcher->addListener(
             $eventName,
             [$mock, $methodName]

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -23,7 +23,6 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use Liip\TestFixturesBundle\Services\DatabaseTools\ORMDatabaseTool;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use function count;
 
 // BC, needed by "theofidry/alice-data-fixtures: <1.3" not compatible with "doctrine/persistence: ^2.0"
 if (interface_exists('\Doctrine\Persistence\ObjectManager')
@@ -219,9 +218,9 @@ class ConfigMysqlTest extends KernelTestCase
         );
 
         // Check that there are 2 users.
-        $this->assertSame(
+        $this->assertCount(
             2,
-            count($this->userRepository->findAll())
+            $this->userRepository->findAll()
         );
 
         $this->databaseTool->setExcludedDoctrineTables(['liip_user']);
@@ -231,9 +230,9 @@ class ConfigMysqlTest extends KernelTestCase
         ;
 
         // The exclusion from purge worked, the user table is still alive and well.
-        $this->assertSame(
+        $this->assertCount(
             2,
-            count($this->userRepository->findAll())
+            $this->userRepository->findAll()
         );
     }
 
@@ -296,9 +295,9 @@ class ConfigMysqlTest extends KernelTestCase
         ;
 
         // The purge worked: there is no user.
-        $this->assertSame(
+        $this->assertCount(
             0,
-            count($this->userRepository->findAll())
+            $this->userRepository->findAll()
         );
     }
 
@@ -323,9 +322,9 @@ class ConfigMysqlTest extends KernelTestCase
 
         $users = $this->userRepository->findAll();
 
-        $this->assertSame(
+        $this->assertCount(
             10,
-            count($users)
+            $users
         );
 
         /** @var User $user */

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -18,10 +18,12 @@ use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\Persistence\ObjectRepository;
 use Liip\Acme\Tests\App\Entity\User;
 use Liip\Acme\Tests\AppConfigMysql\AppConfigMysqlKernel;
+use Liip\Acme\Tests\Traits\ContainerProvider;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use Liip\TestFixturesBundle\Services\DatabaseTools\ORMDatabaseTool;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use function count;
 
 // BC, needed by "theofidry/alice-data-fixtures: <1.3" not compatible with "doctrine/persistence: ^2.0"
 if (interface_exists('\Doctrine\Persistence\ObjectManager')
@@ -51,6 +53,8 @@ if (interface_exists('\Doctrine\Persistence\ObjectManager')
  */
 class ConfigMysqlTest extends KernelTestCase
 {
+    use ContainerProvider;
+
     /** @var ObjectRepository */
     protected $userRepository;
 
@@ -63,11 +67,11 @@ class ConfigMysqlTest extends KernelTestCase
 
         self::bootKernel();
 
-        $this->userRepository = self::$container->get('doctrine')
+        $this->userRepository = $this->getTestContainer()->get('doctrine')
             ->getRepository('LiipAcme:User')
         ;
 
-        $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
+        $this->databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
     }
 
     public function testToolType(): void
@@ -217,7 +221,7 @@ class ConfigMysqlTest extends KernelTestCase
         // Check that there are 2 users.
         $this->assertSame(
             2,
-            \count($this->userRepository->findAll())
+            count($this->userRepository->findAll())
         );
 
         $this->databaseTool->setExcludedDoctrineTables(['liip_user']);
@@ -229,7 +233,7 @@ class ConfigMysqlTest extends KernelTestCase
         // The exclusion from purge worked, the user table is still alive and well.
         $this->assertSame(
             2,
-            \count($this->userRepository->findAll())
+            count($this->userRepository->findAll())
         );
     }
 
@@ -294,7 +298,7 @@ class ConfigMysqlTest extends KernelTestCase
         // The purge worked: there is no user.
         $this->assertSame(
             0,
-            \count($this->userRepository->findAll())
+            count($this->userRepository->findAll())
         );
     }
 
@@ -321,7 +325,7 @@ class ConfigMysqlTest extends KernelTestCase
 
         $this->assertSame(
             10,
-            \count($users)
+            count($users)
         );
 
         /** @var User $user */

--- a/tests/Test/ConfigPhpcrTest.php
+++ b/tests/Test/ConfigPhpcrTest.php
@@ -16,6 +16,7 @@ namespace Liip\Acme\Tests\Test;
 use Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle;
 use Doctrine\ORM\Tools\SchemaTool;
 use Liip\Acme\Tests\AppConfigPhpcr\AppConfigPhpcrKernel;
+use Liip\Acme\Tests\Traits\ContainerProvider;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use Liip\TestFixturesBundle\Services\DatabaseTools\PHPCRDatabaseTool;
@@ -37,6 +38,8 @@ use Symfony\Component\Console\Tester\CommandTester;
  */
 class ConfigPhpcrTest extends KernelTestCase
 {
+    use ContainerProvider;
+
     /** @var AbstractDatabaseTool */
     protected $databaseTool;
 
@@ -52,9 +55,9 @@ class ConfigPhpcrTest extends KernelTestCase
             'environment' => 'phpcr',
         ]);
 
-        $entityManager = self::$container->get('doctrine')->getManager();
+        $entityManager = $this->getTestContainer()->get('doctrine')->getManager();
 
-        $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get('default', 'doctrine_phpcr');
+        $this->databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get('default', 'doctrine_phpcr');
 
         $metadata = $entityManager->getMetadataFactory()->getAllMetadata();
 

--- a/tests/Test/ConfigSqliteTest.php
+++ b/tests/Test/ConfigSqliteTest.php
@@ -30,7 +30,6 @@ use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use Liip\TestFixturesBundle\Services\DatabaseTools\ORMSqliteDatabaseTool;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
-use function count;
 
 /**
  * @preserveGlobalState disabled
@@ -122,9 +121,9 @@ class ConfigSqliteTest extends KernelTestCase
         $users = $this->userRepository->findAll();
 
         // There are 2 users.
-        $this->assertSame(
+        $this->assertCount(
             2,
-            count($users)
+            $users
         );
 
         /** @var User $user */
@@ -164,9 +163,9 @@ class ConfigSqliteTest extends KernelTestCase
         $users = $this->userRepository->findAll();
 
         // Using a non-existing group will result in zero users
-        $this->assertSame(
+        $this->assertCount(
             0,
-            count($users)
+            $users
         );
 
         // Load the fixtures with a valid group.
@@ -187,9 +186,9 @@ class ConfigSqliteTest extends KernelTestCase
         $users = $this->userRepository->findAll();
 
         // The fixture group myGroup contains 3 users
-        $this->assertSame(
+        $this->assertCount(
             3,
-            count($users)
+            $users
         );
 
         // Load all fixtures.
@@ -210,9 +209,9 @@ class ConfigSqliteTest extends KernelTestCase
         $users = $this->userRepository->findAll();
 
         // Loading all fixtures results in 12 users.
-        $this->assertSame(
+        $this->assertCount(
             12,
-            count($users)
+            $users
         );
     }
 
@@ -278,9 +277,9 @@ class ConfigSqliteTest extends KernelTestCase
         $users = $this->userRepository->findAll();
 
         // The two files with fixtures have been loaded, there are 4 users.
-        $this->assertSame(
+        $this->assertCount(
             4,
-            count($users)
+            $users
         );
     }
 
@@ -301,9 +300,9 @@ class ConfigSqliteTest extends KernelTestCase
         $users = $this->userRepository->findAll();
 
         // The two files with fixtures have been loaded, there are 4 users.
-        $this->assertSame(
+        $this->assertCount(
             4,
-            count($users)
+            $users
         );
     }
 
@@ -326,9 +325,9 @@ class ConfigSqliteTest extends KernelTestCase
 
         $users = $this->userRepository->findAll();
 
-        $this->assertSame(
+        $this->assertCount(
             10,
-            count($users)
+            $users
         );
 
         /** @var User $user */
@@ -422,9 +421,9 @@ class ConfigSqliteTest extends KernelTestCase
 
         $users = $this->userRepository->findAll();
 
-        $this->assertSame(
+        $this->assertCount(
             10,
-            count($users)
+            $users
         );
 
         /** @var User $user */
@@ -460,9 +459,9 @@ class ConfigSqliteTest extends KernelTestCase
 
         $users = $this->userRepository->findAll();
 
-        $this->assertSame(
+        $this->assertCount(
             10,
-            count($users)
+            $users
         );
     }
 

--- a/tests/Test/ConfigSqliteTest.php
+++ b/tests/Test/ConfigSqliteTest.php
@@ -25,10 +25,12 @@ use Doctrine\Persistence\ObjectRepository;
 use InvalidArgumentException;
 use Liip\Acme\Tests\App\Entity\User;
 use Liip\Acme\Tests\AppConfigSqlite\AppConfigSqliteKernel;
+use Liip\Acme\Tests\Traits\ContainerProvider;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use Liip\TestFixturesBundle\Services\DatabaseTools\ORMSqliteDatabaseTool;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use function count;
 
 /**
  * @preserveGlobalState disabled
@@ -40,6 +42,8 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  */
 class ConfigSqliteTest extends KernelTestCase
 {
+    use ContainerProvider;
+
     /** @var AbstractDatabaseTool */
     protected $databaseTool;
     /** @var ObjectRepository */
@@ -51,11 +55,11 @@ class ConfigSqliteTest extends KernelTestCase
 
         self::bootKernel();
 
-        $this->userRepository = self::$container->get('doctrine')
+        $this->userRepository = $this->getTestContainer()->get('doctrine')
             ->getRepository('LiipAcme:User')
         ;
 
-        $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
+        $this->databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
     }
 
     public static function getKernelClass(): string
@@ -120,7 +124,7 @@ class ConfigSqliteTest extends KernelTestCase
         // There are 2 users.
         $this->assertSame(
             2,
-            \count($users)
+            count($users)
         );
 
         /** @var User $user */
@@ -162,7 +166,7 @@ class ConfigSqliteTest extends KernelTestCase
         // Using a non-existing group will result in zero users
         $this->assertSame(
             0,
-            \count($users)
+            count($users)
         );
 
         // Load the fixtures with a valid group.
@@ -185,7 +189,7 @@ class ConfigSqliteTest extends KernelTestCase
         // The fixture group myGroup contains 3 users
         $this->assertSame(
             3,
-            \count($users)
+            count($users)
         );
 
         // Load all fixtures.
@@ -208,7 +212,7 @@ class ConfigSqliteTest extends KernelTestCase
         // Loading all fixtures results in 12 users.
         $this->assertSame(
             12,
-            \count($users)
+            count($users)
         );
     }
 
@@ -276,7 +280,7 @@ class ConfigSqliteTest extends KernelTestCase
         // The two files with fixtures have been loaded, there are 4 users.
         $this->assertSame(
             4,
-            \count($users)
+            count($users)
         );
     }
 
@@ -299,7 +303,7 @@ class ConfigSqliteTest extends KernelTestCase
         // The two files with fixtures have been loaded, there are 4 users.
         $this->assertSame(
             4,
-            \count($users)
+            count($users)
         );
     }
 
@@ -324,7 +328,7 @@ class ConfigSqliteTest extends KernelTestCase
 
         $this->assertSame(
             10,
-            \count($users)
+            count($users)
         );
 
         /** @var User $user */
@@ -420,7 +424,7 @@ class ConfigSqliteTest extends KernelTestCase
 
         $this->assertSame(
             10,
-            \count($users)
+            count($users)
         );
 
         /** @var User $user */
@@ -458,7 +462,7 @@ class ConfigSqliteTest extends KernelTestCase
 
         $this->assertSame(
             10,
-            \count($users)
+            count($users)
         );
     }
 

--- a/tests/Test/ConfigSqliteTest.php
+++ b/tests/Test/ConfigSqliteTest.php
@@ -58,7 +58,7 @@ class ConfigSqliteTest extends KernelTestCase
         $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
     }
 
-    public static function getKernelClass()
+    public static function getKernelClass(): string
     {
         return AppConfigSqliteKernel::class;
     }

--- a/tests/Test/ConfigSqliteUrlTest.php
+++ b/tests/Test/ConfigSqliteUrlTest.php
@@ -34,7 +34,7 @@ use Liip\Acme\Tests\AppConfigSqliteUrl\AppConfigSqliteUrlKernel;
  */
 class ConfigSqliteUrlTest extends ConfigSqliteTest
 {
-    public static function getKernelClass()
+    public static function getKernelClass(): string
     {
         return AppConfigSqliteUrlKernel::class;
     }

--- a/tests/Test/ConfigTest.php
+++ b/tests/Test/ConfigTest.php
@@ -23,6 +23,7 @@ use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Doctrine\Persistence\ObjectRepository;
 use Liip\Acme\Tests\App\Entity\User;
 use Liip\Acme\Tests\AppConfig\AppConfigKernel;
+use Liip\Acme\Tests\Traits\ContainerProvider;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
@@ -46,6 +47,8 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  */
 class ConfigTest extends KernelTestCase
 {
+    use ContainerProvider;
+
     /** @var AbstractDatabaseTool */
     protected $databaseTool;
     /** @var ObjectRepository */
@@ -60,13 +63,13 @@ class ConfigTest extends KernelTestCase
 
         self::bootKernel();
 
-        $this->userRepository = self::$container->get('doctrine')
+        $this->userRepository = $this->getTestContainer()->get('doctrine')
             ->getRepository('LiipAcme:User')
         ;
 
-        $this->databaseTool = self::$container->get(DatabaseToolCollection::class)->get();
+        $this->databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
 
-        $this->kernelCacheDir = self::$container->getParameter('kernel.cache_dir');
+        $this->kernelCacheDir = $this->getTestContainer()->getParameter('kernel.cache_dir');
     }
 
     /**

--- a/tests/Traits/ContainerProvider.php
+++ b/tests/Traits/ContainerProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/TestFixturesBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\Traits;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+trait ContainerProvider
+{
+    public function getTestContainer(): ContainerInterface
+    {
+        // Used by Symfony <= 5.3 because static::getContainer() doesn't exist.
+        if (property_exists($this, 'container')) {
+            return self::$container;
+        }
+
+        return static::getContainer();
+    }
+}


### PR DESCRIPTION
When PHP 8.1 will be released and available on CI, and when Symfony 6 will be released:

- [x] remove the dependencies that were added only to allow the unstable versions
- [x] replace `^6.0.0-BETA3` with `^6.0`
- [x] restore PHPCR for Symfony 6, it will require https://github.com/doctrine/phpcr-odm/pull/821 and an update in https://github.com/doctrine/DoctrinePHPCRBundle/blob/master/composer.json → see #161