### PR TITLE
Allow new contracts version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.2 || ^8.0",
         "doctrine/common": "^2.13 || ^3.0",
         "symfony/event-dispatcher": "^4.4 || ^5.4 || ^6.0",
-        "symfony/event-dispatcher-contracts": "^1 || ^2",
+        "symfony/event-dispatcher-contracts": "^1 || ^2 || ^3",
         "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^4.4 || ^5.4 || ^6.0"
     },


### PR DESCRIPTION
Alongside Symfony 6, all the contract packages got 3.0 releases.  So, the new version of the contracts should also be allowed.