### PR TITLE
fix: sqlite bug with getListDatabasesSQL

### DIFF
--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -160,7 +160,11 @@ class ORMDatabaseTool extends AbstractDatabaseTool
         $tmpConnection = DriverManager::getConnection($params);
         $tmpConnection->connect();
 
-        if (!\in_array($dbName, $tmpConnection->getSchemaManager()->listDatabases(), true)) {
+        $databases = $tmpConnection->getDatabasePlatform() instanceof SqlitePlatform
+            ? ['']
+            : $tmpConnection->getSchemaManager()->listDatabases();
+
+        if (!\in_array($dbName, $databases, true)) {
             $tmpConnection->getSchemaManager()->createDatabase($dbName);
         }
 

--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -19,6 +19,7 @@ use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use Liip\TestFixturesBundle\Event\FixtureEvent;


### PR DESCRIPTION
fixed the folloging sqlite bug
Doctrine\DBAL\Exception: Operation 'Doctrine\DBAL\Platforms\AbstractPlatform::getListDatabasesSQL' is not supported by platform.