### PR TITLE
fix error with the annotations.reader service

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,13 +91,13 @@ jobs:
         if: matrix.composer-flags == ''
         run: composer install
 
-      - name: Show Composer dependencies
-        run: composer show
-
       - name: Install Composer dependencies with options
         if: matrix.composer-flags != ''
         # Use "update" instead of "install" since it allows using the "--prefer-lowest" option
         run: composer update ${{ matrix.composer-flags }}
+
+      - name: Show Composer dependencies
+        run: composer show
 
       - name: Run tests
         # In phpunit.xml.dist, tests annotated with "@group mysql" are excluded, revert this

--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,8 @@
         "theofidry/alice-data-fixtures": "^1.0.1"
     },
     "conflict": {
-        "doctrine/dbal": "<2.11"
+        "doctrine/dbal": "<2.11",
+        "doctrine/persistence": ">=2.3.0"
     },
     "suggest": {
         "doctrine/dbal": "Required when using the fixture loading functionality with an ORM and SQLite",
@@ -60,7 +61,11 @@
         }
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true,
+            "ocramius/package-versions": true
+        }
     },
     "extra": {
         "branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -63,8 +63,7 @@
     "config": {
         "sort-packages": true,
         "allow-plugins": {
-            "composer/package-versions-deprecated": true,
-            "ocramius/package-versions": true
+            "composer/package-versions-deprecated": true
         }
     },
     "extra": {

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/cache": "^1.10.0",
         "doctrine/orm": "^2.7",
+        "doctrine/persistence": "^1.3 || ^2.0 ,<2.3.0",
         "doctrine/phpcr-bundle": "^2.0.2",
         "doctrine/phpcr-odm": "^1.3",
         "jackalope/jackalope-doctrine-dbal": "^1.5",
@@ -40,8 +41,7 @@
         "theofidry/alice-data-fixtures": "^1.0.1"
     },
     "conflict": {
-        "doctrine/dbal": "<2.11",
-        "doctrine/persistence": ">=2.3.0"
+        "doctrine/dbal": "<2.11"
     },
     "suggest": {
         "doctrine/dbal": "Required when using the fixture loading functionality with an ORM and SQLite",


### PR DESCRIPTION
Related to https://github.com/doctrine/persistence/pull/197?

This is the only difference in dependencies between these 2 PHPunit runs:
- pass: https://github.com/liip/LiipTestFixturesBundle/runs/4729494716?check_suite_focus=true
- failed: https://github.com/liip/LiipTestFixturesBundle/runs/4776332809?check_suite_focus=true

Here are the changes between the 2 versions of doctrine/persistence: [diff](https://github.com/doctrine/persistence/compare/2.2.4...2.3.0#diff-c471496bcb3ed47397b73d2e3e3aa41a8a679c86accaed9e05676fd9d5987434)