### PR TITLE
remove restriction on version of doctrine/persistence

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,6 +16,7 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
+        "doctrine/annotations": "^1.2.7",
         "doctrine/common": "^2.13 || ^3.0",
         "symfony/event-dispatcher": "^4.4 || ^5.4 || ^6.0",
         "symfony/event-dispatcher-contracts": "^1 || ^2 || ^3",

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
         "doctrine/cache": "^1.10.0",
         "doctrine/orm": "^2.7",
-        "doctrine/persistence": "^1.3 || ^2.0 ,<2.3.0",
+        "doctrine/persistence": "^1.3 || ^2.0",
         "doctrine/phpcr-bundle": "^2.0.2",
         "doctrine/phpcr-odm": "^1.3",
         "jackalope/jackalope-doctrine-dbal": "^1.5",


### PR DESCRIPTION
Follow up of #169, revert a change that should not be needed, but is required to run tests.

Any help is welcome.