### PR TITLE
Test the type of the database tool before running tests

### DIFF
--- a/tests/Test/ConfigEventsTest.php
+++ b/tests/Test/ConfigEventsTest.php
@@ -20,6 +20,7 @@ use Liip\Acme\Tests\Traits\ContainerProvider;
 use Liip\TestFixturesBundle\LiipTestFixturesEvents;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
+use Liip\TestFixturesBundle\Services\DatabaseTools\ORMSqliteDatabaseTool;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -53,6 +54,8 @@ class ConfigEventsTest extends KernelTestCase
     public function testLoadEmptyFixturesAndCheckEvents(): void
     {
         $databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
+
+        $this->assertInstanceOf(ORMSqliteDatabaseTool::class, $databaseTool);
 
         $fixtures = $databaseTool->loadFixtures([]);
 
@@ -90,6 +93,8 @@ class ConfigEventsTest extends KernelTestCase
     {
         /** @var AbstractDatabaseTool $databaseTool */
         $databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
+
+        $this->assertInstanceOf(ORMSqliteDatabaseTool::class, $databaseTool);
 
         // Create the mock and declare that the method must be called (or not)
         $mock = $this->getMockBuilder(FixturesSubscriber::class)->getMock();

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -71,10 +71,7 @@ class ConfigMysqlTest extends KernelTestCase
         ;
 
         $this->databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
-    }
 
-    public function testToolType(): void
-    {
         $this->assertInstanceOf(ORMDatabaseTool::class, $this->databaseTool);
     }
 

--- a/tests/Test/ConfigPhpcrTest.php
+++ b/tests/Test/ConfigPhpcrTest.php
@@ -63,6 +63,8 @@ class ConfigPhpcrTest extends KernelTestCase
 
         $this->databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get('default', 'doctrine_phpcr');
 
+        $this->assertInstanceOf(PHPCRDatabaseTool::class, $this->databaseTool);
+
         $metadata = $entityManager->getMetadataFactory()->getAllMetadata();
 
         $schemaTool = new SchemaTool($entityManager);
@@ -72,11 +74,6 @@ class ConfigPhpcrTest extends KernelTestCase
         }
 
         $this->initRepository();
-    }
-
-    public function testToolType(): void
-    {
-        $this->assertInstanceOf(PHPCRDatabaseTool::class, $this->databaseTool);
     }
 
     public function testLoadFixturesPhPCr(): void

--- a/tests/Test/ConfigSqliteTest.php
+++ b/tests/Test/ConfigSqliteTest.php
@@ -60,16 +60,13 @@ class ConfigSqliteTest extends KernelTestCase
         ;
 
         $this->databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
+
+        $this->assertInstanceOf(ORMSqliteDatabaseTool::class, $this->databaseTool);
     }
 
     public static function getKernelClass(): string
     {
         return AppConfigSqliteKernel::class;
-    }
-
-    public function testToolType(): void
-    {
-        $this->assertInstanceOf(ORMSqliteDatabaseTool::class, $this->databaseTool);
     }
 
     public function testLoadEmptyFixtures(): void

--- a/tests/Test/ConfigTest.php
+++ b/tests/Test/ConfigTest.php
@@ -26,6 +26,7 @@ use Liip\Acme\Tests\AppConfig\AppConfigKernel;
 use Liip\Acme\Tests\Traits\ContainerProvider;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
 use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
+use Liip\TestFixturesBundle\Services\DatabaseTools\ORMSqliteDatabaseTool;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
@@ -68,6 +69,8 @@ class ConfigTest extends KernelTestCase
         ;
 
         $this->databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get();
+
+        $this->assertInstanceOf(ORMSqliteDatabaseTool::class, $this->databaseTool);
 
         $this->kernelCacheDir = $this->getTestContainer()->getParameter('kernel.cache_dir');
     }


### PR DESCRIPTION
This will help us to identify issues like #154 more easily, the issue was not with Doctrine, it was a problem when loading a wrong database driver.