### PR TITLE
fix(sqlite): Detect driver by platform to work around middlewares

### DIFF
--- a/src/Services/DatabaseToolCollection.php
+++ b/src/Services/DatabaseToolCollection.php
@@ -47,7 +47,7 @@ final class DatabaseToolCollection
     {
         /** @var ManagerRegistry $registry */
         $registry = $this->container->get($registryName);
-        $driverName = ('ORM' === $registry->getName()) ? \get_class($registry->getConnection()->getDriver()) : 'default';
+        $driverName = ('ORM' === $registry->getName()) ? \get_class($registry->getConnection()->getDatabasePlatform()) : 'default';
 
         $databaseTool = isset($this->items[$registry->getName()][$driverName])
             ? $this->items[$registry->getName()][$driverName]

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -36,7 +36,7 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
 
     public function getDriverName(): string
     {
-        return Driver::class;
+        return SqlitePlatform::class;
     }
 
     public function loadFixtures(array $classNames = [], bool $append = false): AbstractExecutor

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -15,7 +15,6 @@ namespace Liip\TestFixturesBundle\Services\DatabaseTools;
 
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
-use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\ORM\Tools\SchemaTool;
 use Liip\TestFixturesBundle\Event\FixtureEvent;


### PR DESCRIPTION
After leaving this comment https://github.com/liip/LiipTestFixturesBundle/issues/154#issuecomment-1085248596 I continued digging into the issue and realised that we can indeed detect the type of database better to handle the new middlewares issue with DoctrineBundle 2.6. We can use the Platform instead of the Driver. 

I couldn't find any tests that specifically cover this, but I've run it in my project using DoctrineBundle 2.6.0 and it indeed fixes the issue. If there are tests required for this change, please point me in the right direction and I'm happy to add them to the PR.

Also, I'm not sure if we want to change the `getDriverName()` since we're now returning a platform name instead? However we still want to use the `default` driver name for anything that is not sqlite so :shrug: 

Closes: #154