### PR TITLE
Revert "Don't use doctrine/cache 2 during tests"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,6 @@
         "doctrine/data-fixtures": "^1.3",
         "doctrine/doctrine-bundle": "^2.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
-        "doctrine/cache": "^1.10.0",
         "doctrine/orm": "^2.7",
         "doctrine/persistence": "^1.3 || ^2.0",
         "doctrine/phpcr-bundle": "^2.0.2",


### PR DESCRIPTION
This reverts commit 24efc86263c81cf698a8347ea464143a54986bc9.

Fixes  #140