### PR TITLE
Replace usage of deprecated ClassMetaFactory::getCacheDriver

### DIFF
--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -50,10 +50,10 @@ class ORMDatabaseTool extends AbstractDatabaseTool
     public function loadFixtures(array $classNames = [], bool $append = false): AbstractExecutor
     {
         $referenceRepository = new ProxyReferenceRepository($this->om);
-        $cacheDriver = $this->om->getMetadataFactory()->getCacheDriver();
+        $cacheDriver = $this->om->getConnection()->getCacheDriver();
 
         if ($cacheDriver) {
-            $cacheDriver->deleteAll();
+            $cacheDriver->clear();
         }
 
         if (false === $this->getKeepDatabaseAndSchemaParameter()) {


### PR DESCRIPTION
Addresses #182 

As described in https://github.com/liip/LiipTestFixturesBundle/issues/182#issuecomment-1115096438

This preserves the current behaviour of clearing the metadata cache.