### PR TITLE
Use the object manager configuration to retrieve the metadata cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^7.2 || ^8.0",
         "doctrine/common": "^2.13 || ^3.0",
+        "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
         "symfony/event-dispatcher": "^4.4 || ^5.4 || ^6.0",
         "symfony/event-dispatcher-contracts": "^1 || ^2",
         "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",

--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -19,6 +19,7 @@ use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\DriverManager;
 use Doctrine\DBAL\Platforms\MySqlPlatform;
+use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
 use Liip\TestFixturesBundle\Event\FixtureEvent;
@@ -50,10 +51,22 @@ class ORMDatabaseTool extends AbstractDatabaseTool
     public function loadFixtures(array $classNames = [], bool $append = false): AbstractExecutor
     {
         $referenceRepository = new ProxyReferenceRepository($this->om);
-        $cacheDriver = $this->om->getMetadataFactory()->getCacheDriver();
 
-        if ($cacheDriver) {
-            $cacheDriver->deleteAll();
+        /** @var Configuration $config */
+        $config = $this->om->getConfiguration();
+
+        if (method_exists($config, 'getMetadataCache')) {
+            $cacheDriver = $config->getMetadataCache();
+
+            if ($cacheDriver) {
+                $cacheDriver->clear();
+            }
+        } else {
+            $cacheDriver = $config->getMetadataCacheImpl();
+
+            if ($cacheDriver) {
+                $cacheDriver->deleteAll();
+            }
         }
 
         if (false === $this->getKeepDatabaseAndSchemaParameter()) {

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -17,6 +17,7 @@ use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\DBAL\Driver\PDO\SQLite\Driver;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
+use Doctrine\ORM\Configuration;
 use Doctrine\ORM\Tools\SchemaTool;
 use Liip\TestFixturesBundle\Event\FixtureEvent;
 use Liip\TestFixturesBundle\Event\PostFixtureBackupRestoreEvent;
@@ -42,10 +43,22 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
     public function loadFixtures(array $classNames = [], bool $append = false): AbstractExecutor
     {
         $referenceRepository = new ProxyReferenceRepository($this->om);
-        $cacheDriver = $this->om->getMetadataFactory()->getCacheDriver();
 
-        if ($cacheDriver) {
-            $cacheDriver->deleteAll();
+        /** @var Configuration $config */
+        $config = $this->om->getConfiguration();
+
+        if (method_exists($config, 'getMetadataCache')) {
+            $cacheDriver = $config->getMetadataCache();
+
+            if ($cacheDriver) {
+                $cacheDriver->clear();
+            }
+        } else {
+            $cacheDriver = $config->getMetadataCacheImpl();
+
+            if ($cacheDriver) {
+                $cacheDriver->deleteAll();
+            }
         }
 
         $backupService = $this->getBackupService();

--- a/src/Services/DatabaseTools/PHPCRDatabaseTool.php
+++ b/src/Services/DatabaseTools/PHPCRDatabaseTool.php
@@ -17,6 +17,7 @@ use Doctrine\Bundle\PHPCRBundle\Initializer\InitializerManager;
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\DataFixtures\Purger\PHPCRPurger;
+use Doctrine\ODM\PHPCR\Configuration;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Liip\TestFixturesBundle\Event\PostFixtureBackupRestoreEvent;
 use Liip\TestFixturesBundle\Event\PreFixtureBackupRestoreEvent;
@@ -41,7 +42,11 @@ class PHPCRDatabaseTool extends AbstractDatabaseTool
     public function loadFixtures(array $classNames = [], bool $append = false): AbstractExecutor
     {
         $referenceRepository = new ProxyReferenceRepository($this->om);
-        $cacheDriver = $this->om->getMetadataFactory()->getCacheDriver();
+
+        /** @var Configuration $config */
+        $config = $this->om->getConfiguration();
+
+        $cacheDriver = $config->getMetadataCacheImpl();
 
         if ($cacheDriver) {
             $cacheDriver->deleteAll();


### PR DESCRIPTION
More complete version of #186 patching all of the database tool implementations.

This also adds `doctrine/persistence` as a direct dependency to this bundle and declares supported versions.