### PR TITLE
Remove unnecessary properties of the test entity (User)

### DIFF
--- a/tests/App/DataFixtures/ORM/LoadDependentUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadDependentUserData.php
@@ -16,29 +16,16 @@ namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Liip\Acme\Tests\App\Entity\User;
 
 class LoadDependentUserData extends AbstractFixture implements DependentFixtureInterface
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null): void
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var \Liip\Acme\Tests\App\Entity\User $user */
+        /** @var User $user */
         $user = clone $this->getReference('user');
 
         $user->setId(3);

--- a/tests/App/DataFixtures/ORM/LoadDependentUserWithServiceData.php
+++ b/tests/App/DataFixtures/ORM/LoadDependentUserWithServiceData.php
@@ -16,29 +16,16 @@ namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
-use Symfony\Component\DependencyInjection\ContainerInterface;
+use Liip\Acme\Tests\App\Entity\User;
 
 class LoadDependentUserWithServiceData extends AbstractFixture implements DependentFixtureInterface
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null): void
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var \Liip\Acme\Tests\App\Entity\User $user */
+        /** @var User $user */
         $user = clone $this->getReference('serviceUser');
 
         $user->setId(3);

--- a/tests/App/DataFixtures/ORM/LoadSecondUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadSecondUserData.php
@@ -17,36 +17,18 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LoadSecondUserData extends AbstractFixture implements FixtureInterface
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null): void
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var \Liip\Acme\Tests\App\Entity\User $user */
+        /** @var User $user */
         $user = new User();
         $user->setName('bar foo');
         $user->setEmail('bar@foo.com');
-        $user->setPassword('12341234');
-        $user->setAlgorithm('plaintext');
-        $user->setEnabled(true);
-        $user->setConfirmationToken(null);
 
         $manager->persist($user);
         $manager->flush();

--- a/tests/App/DataFixtures/ORM/LoadUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserData.php
@@ -17,37 +17,19 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LoadUserData extends AbstractFixture implements FixtureInterface
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null): void
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var \Liip\Acme\Tests\App\Entity\User $user */
+        /** @var User $user */
         $user = new User();
         $user->setId(1);
         $user->setName('foo bar');
         $user->setEmail('foo@bar.com');
-        $user->setPassword('12341234');
-        $user->setAlgorithm('plaintext');
-        $user->setEnabled(true);
-        $user->setConfirmationToken(null);
 
         $manager->persist($user);
         $manager->flush();

--- a/tests/App/DataFixtures/ORM/LoadUserDataInGroup.php
+++ b/tests/App/DataFixtures/ORM/LoadUserDataInGroup.php
@@ -18,37 +18,19 @@ use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 
 class LoadUserDataInGroup extends AbstractFixture implements FixtureInterface, FixtureGroupInterface
 {
-    /**
-     * @var ContainerInterface
-     */
-    private $container;
-
-    /**
-     * {@inheritdoc}
-     */
-    public function setContainer(ContainerInterface $container = null): void
-    {
-        $this->container = $container;
-    }
-
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var \Liip\Acme\Tests\App\Entity\User $user */
+        /** @var User $user */
         $user = new User();
         $user->setId(1);
         $user->setName('foo bar');
         $user->setEmail('foo@bar.com');
-        $user->setPassword('12341234');
-        $user->setAlgorithm('plaintext');
-        $user->setEnabled(true);
-        $user->setConfirmationToken(null);
 
         $manager->persist($user);
         $manager->flush();

--- a/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
@@ -30,10 +30,6 @@ class LoadUserWithServiceData extends AbstractFixture implements FixtureInterfac
         $user->setId(1);
         $user->setName('foo bar');
         $user->setEmail('foo@bar.com');
-        $user->setPassword('12341234');
-        $user->setAlgorithm('plaintext');
-        $user->setEnabled(true);
-        $user->setConfirmationToken(null);
 
         $manager->persist($user);
         $manager->flush();

--- a/tests/App/DataFixtures/ORM/user.yml
+++ b/tests/App/DataFixtures/ORM/user.yml
@@ -2,6 +2,3 @@ Liip\Acme\Tests\App\Entity\User:
     id{1..10}:
         name: <name()>
         email: <email()>
-        password: <name()>
-        algorithm: "sha1"
-        enabled: true

--- a/tests/App/DataFixtures/ORM/user_with_custom_provider.yml
+++ b/tests/App/DataFixtures/ORM/user_with_custom_provider.yml
@@ -2,6 +2,3 @@ Liip\Acme\Tests\App\Entity\User:
     id{1..10}:
         name: <foo('a string')>
         email: <email()>
-        password: <name()>
-        algorithm: "sha1"
-        enabled: true

--- a/tests/App/Entity/User.php
+++ b/tests/App/Entity/User.php
@@ -18,48 +18,25 @@ namespace Liip\Acme\Tests\App\Entity;
  */
 class User
 {
-    // Properties which will be serialized have to be "protected"
-    // @see http://stackoverflow.com/questions/9384836/symfony2-serialize-entity-object-to-session/10014802#10014802
-
     /**
      * @var int
      */
-    protected $id;
+    private $id;
 
     /**
      * @var string
      */
-    protected $name;
+    private $name;
 
     /**
      * @var string
      */
-    protected $password;
-
-    /**
-     * @var string
-     */
-    protected $salt;
+    private $salt;
 
     /**
      * @var string
      */
     private $email;
-
-    /**
-     * @var string
-     */
-    private $algorithm;
-
-    /**
-     * @var bool
-     */
-    private $enabled;
-
-    /**
-     * @var string
-     */
-    private $confirmationToken;
 
     public function __construct()
     {
@@ -69,242 +46,51 @@ class User
         );
     }
 
-    // @see http://stackoverflow.com/questions/9384836/symfony2-serialize-entity-object-to-session/19133985#19133985
-
-    public function __sleep()
-    {
-        // these are field names to be serialized, others will be excluded
-        // but note that you have to fill other field values by your own
-        return ['id', 'name', 'password', 'salt'];
-    }
-
-    /**
-     * Set id.
-     *
-     * @param int $id
-     *
-     * @return User
-     */
-    public function setId($id)
+    public function setId(int $id): self
     {
         $this->id = $id;
 
         return $this;
     }
 
-    /**
-     * Get id.
-     *
-     * @return int
-     */
-    public function getId()
+    public function getId(): int
     {
         return $this->id;
     }
 
-    /**
-     * Set name.
-     *
-     * @param string $name
-     *
-     * @return User
-     */
-    public function setName($name)
+    public function setName(string $name): self
     {
         $this->name = $name;
 
         return $this;
     }
 
-    /**
-     * Get name.
-     *
-     * @return string
-     */
-    public function getName()
+    public function getName(): string
     {
         return $this->name;
     }
 
-    /**
-     * Set email.
-     *
-     * @param string $email
-     *
-     * @return User
-     */
-    public function setEmail($email)
+    public function setEmail(string $email): self
     {
         $this->email = $email;
 
         return $this;
     }
 
-    /**
-     * Get email.
-     *
-     * @return string
-     */
-    public function getEmail()
+    public function getEmail(): string
     {
         return $this->email;
     }
 
-    /**
-     * Set password.
-     *
-     * @param string $password
-     *
-     * @return User
-     */
-    public function setPassword($password)
-    {
-        $this->password = $password;
-
-        return $this;
-    }
-
-    /**
-     * Get password.
-     *
-     * @return string
-     */
-    public function getPassword()
-    {
-        return $this->password;
-    }
-
-    /**
-     * Set salt.
-     *
-     * @param string $salt
-     *
-     * @return User
-     */
-    public function setSalt($salt)
+    public function setSalt(string $salt): self
     {
         $this->salt = $salt;
 
         return $this;
     }
 
-    /**
-     * Get salt.
-     *
-     * @return string
-     */
-    public function getSalt()
+    public function getSalt(): string
     {
         return $this->salt;
-    }
-
-    /**
-     * Set algorithm.
-     *
-     * @param string $algorithm
-     *
-     * @return User
-     */
-    public function setAlgorithm($algorithm)
-    {
-        $this->algorithm = $algorithm;
-
-        return $this;
-    }
-
-    /**
-     * Get algorithm.
-     *
-     * @return string
-     */
-    public function getAlgorithm()
-    {
-        return $this->algorithm;
-    }
-
-    /**
-     * Set enabled.
-     *
-     * @param bool $enabled
-     *
-     * @return User
-     */
-    public function setEnabled($enabled)
-    {
-        $this->enabled = $enabled;
-
-        return $this;
-    }
-
-    /**
-     * Get enabled.
-     *
-     * @return bool
-     */
-    public function getEnabled()
-    {
-        return $this->enabled;
-    }
-
-    /**
-     * Set confirmationToken.
-     *
-     * @param string $confirmationToken
-     *
-     * @return User
-     */
-    public function setConfirmationToken($confirmationToken)
-    {
-        $this->confirmationToken = $confirmationToken;
-
-        return $this;
-    }
-
-    /**
-     * Get confirmationToken.
-     *
-     * @return string
-     */
-    public function getConfirmationToken()
-    {
-        return $this->confirmationToken;
-    }
-
-    // Functions required for compatibility with UserInterface
-    // @see http://symfony.com/doc/2.3/cookbook/security/custom_provider.html
-
-    public function getRoles()
-    {
-        return ['ROLE_ADMIN'];
-    }
-
-    public function getUsername()
-    {
-        return $this->getName();
-    }
-
-    public function eraseCredentials(): void
-    {
-    }
-
-    public function isEqualTo($user)
-    {
-        if (!$user instanceof self) {
-            return false;
-        }
-
-        if ($this->id !== $user->getId()) {
-            return false;
-        }
-
-        if ($this->password !== $user->getPassword()) {
-            return false;
-        }
-
-        if ($this->salt !== $user->getSalt()) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/tests/App/Resources/config/doctrine/User.orm.yml
+++ b/tests/App/Resources/config/doctrine/User.orm.yml
@@ -14,20 +14,6 @@ Liip\Acme\Tests\App\Entity\User:
         email:
             type: string
             length: '255'
-        password:
-            type: string
-            length: '255'
         salt:
             type: string
             length: '255'
-        algorithm:
-            type: string
-            length: '255'
-        enabled:
-            type: boolean
-            length: null
-        confirmationToken:
-            type: string
-            length: '255'
-            nullable: true
-    lifecycleCallbacks: { }

--- a/tests/Test/ConfigMysqlCacheDbTest.php
+++ b/tests/Test/ConfigMysqlCacheDbTest.php
@@ -71,10 +71,6 @@ class ConfigMysqlCacheDbTest extends ConfigMysqlTest
             $user1->getEmail()
         );
 
-        $this->assertTrue(
-            $user1->getEnabled()
-        );
-
         // Store salt for later use
         $salt = $user1->getSalt();
 

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -115,7 +115,6 @@ class ConfigMysqlTest extends KernelTestCase
 
         $this->assertSame('foo bar', $user1->getName());
         $this->assertSame('foo@bar.com', $user1->getEmail());
-        $this->assertTrue($user1->getEnabled());
 
         // Load data from database
         /** @var User $user */
@@ -128,10 +127,6 @@ class ConfigMysqlTest extends KernelTestCase
         $this->assertSame(
             'foo@bar.com',
             $user->getEmail()
-        );
-
-        $this->assertTrue(
-            $user->getEnabled()
         );
     }
 
@@ -172,10 +167,6 @@ class ConfigMysqlTest extends KernelTestCase
             $user1->getEmail()
         );
 
-        $this->assertTrue(
-            $user1->getEnabled()
-        );
-
         /** @var User $user */
         $user3 = $this->userRepository
             ->findOneBy([
@@ -188,10 +179,6 @@ class ConfigMysqlTest extends KernelTestCase
         $this->assertSame(
             'bar@foo.com',
             $user3->getEmail()
-        );
-
-        $this->assertTrue(
-            $user3->getEnabled()
         );
     }
 
@@ -333,19 +320,13 @@ class ConfigMysqlTest extends KernelTestCase
 
         $this->assertInstanceOf(User::class, $user);
 
-        $this->assertTrue(
-            $user->getEnabled()
-        );
-
         $user = $this->userRepository
             ->findOneBy([
                 'id' => 10,
             ])
         ;
 
-        $this->assertTrue(
-            $user->getEnabled()
-        );
+        $this->assertInstanceOf(User::class, $user);
     }
 
     protected static function getKernelClass(): string

--- a/tests/Test/ConfigSqliteTest.php
+++ b/tests/Test/ConfigSqliteTest.php
@@ -113,7 +113,6 @@ class ConfigSqliteTest extends KernelTestCase
         $this->assertSame(1, $user1->getId());
         $this->assertSame('foo bar', $user1->getName());
         $this->assertSame('foo@bar.com', $user1->getEmail());
-        $this->assertTrue($user1->getEnabled());
 
         // Load data from database
         $users = $this->userRepository->findAll();
@@ -134,10 +133,6 @@ class ConfigSqliteTest extends KernelTestCase
         $this->assertSame(
             'foo@bar.com',
             $user->getEmail()
-        );
-
-        $this->assertTrue(
-            $user->getEnabled()
         );
     }
 
@@ -237,10 +232,6 @@ class ConfigSqliteTest extends KernelTestCase
             $user->getEmail()
         );
 
-        $this->assertTrue(
-            $user->getEnabled()
-        );
-
         /** @var User $user */
         $user = $this->userRepository
             ->findOneBy([
@@ -251,10 +242,6 @@ class ConfigSqliteTest extends KernelTestCase
         $this->assertSame(
             'bar@foo.com',
             $user->getEmail()
-        );
-
-        $this->assertTrue(
-            $user->getEnabled()
         );
     }
 
@@ -337,9 +324,7 @@ class ConfigSqliteTest extends KernelTestCase
 
         $this->assertInstanceOf(User::class, $user);
 
-        $this->assertTrue(
-            $user->getEnabled()
-        );
+        $this->assertIsString($user->getName());
 
         $user = $this->userRepository
             ->findOneBy([
@@ -347,9 +332,7 @@ class ConfigSqliteTest extends KernelTestCase
             ])
         ;
 
-        $this->assertTrue(
-            $user->getEnabled()
-        );
+        $this->assertIsString($user->getName());
     }
 
     /**
@@ -414,8 +397,7 @@ class ConfigSqliteTest extends KernelTestCase
         /** @var User $user1 */
         $user1 = $fixtures['id1'];
 
-        $this->assertIsString($user1->getUsername());
-        $this->assertTrue($user1->getEnabled());
+        $this->assertIsString($user1->getEmail());
 
         $users = $this->userRepository->findAll();
 
@@ -433,9 +415,7 @@ class ConfigSqliteTest extends KernelTestCase
 
         $this->assertInstanceOf(User::class, $user);
 
-        $this->assertTrue(
-            $user->getEnabled()
-        );
+        $this->assertIsString($user->getName());
     }
 
     /**


### PR DESCRIPTION
- remove properties that were required when `User` extended `Symfony\Component\Security\Core\User\UserInterface`, now they are useless
- add return types to the entity