### PR TITLE
Deprecate providing an annotation reader to DatabaseToolCollection, allow doctrine/annotations 2.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -83,6 +83,10 @@ jobs:
           composer config extra.symfony.require "${{ matrix.symfony-version }}"
           composer require --no-update symfony/framework-bundle=${{ matrix.symfony-version }}
 
+      # This is needed to fix builds on Symfony 5.4 where the `annotation_reader` service may not be set up if the Annotations package is not in the production dependencies
+      - name: Move Annotations to require
+        run: composer require --no-update "doctrine/annotations:^1.2.7|^2.0"
+
       - name: Install Composer dependencies
         if: matrix.composer-flags == ''
         run: composer install

--- a/composer.json
+++ b/composer.json
@@ -16,15 +16,16 @@
     ],
     "require": {
         "php": "^7.2 || ^8.0",
-        "doctrine/annotations": "^1.2.7",
         "doctrine/common": "^2.13 || ^3.0",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
+        "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/event-dispatcher": "^4.4 || ^5.4 || ^6.0",
         "symfony/event-dispatcher-contracts": "^1 || ^2 || ^3",
         "symfony/framework-bundle": "^4.4 || ^5.4 || ^6.0",
         "symfony/yaml": "^4.4 || ^5.4 || ^6.0"
     },
     "require-dev": {
+        "doctrine/annotations": "^1.2.7 || ^2.0",
         "doctrine/data-fixtures": "^1.3",
         "doctrine/doctrine-bundle": "^2.1",
         "doctrine/doctrine-fixtures-bundle": "^3.0.2",
@@ -41,6 +42,7 @@
         "theofidry/alice-data-fixtures": "^1.0.1"
     },
     "conflict": {
+        "doctrine/annotations": "<1.2.7 || >=3.0",
         "doctrine/dbal": "<2.11"
     },
     "suggest": {

--- a/src/Resources/config/database_tools.xml
+++ b/src/Resources/config/database_tools.xml
@@ -43,7 +43,7 @@
         </service>
         <service id="Liip\TestFixturesBundle\Services\DatabaseToolCollection" public="true">
             <argument type="service" id="service_container" />
-            <argument type="service" id="annotations.reader" />
+            <argument>null</argument> <!-- deprecated argument -->
             <call method="add">
                 <argument type="service" id="Liip\TestFixturesBundle\Services\DatabaseTools\ORMDatabaseTool" />
             </call>

--- a/src/Services/DatabaseToolCollection.php
+++ b/src/Services/DatabaseToolCollection.php
@@ -32,10 +32,14 @@ final class DatabaseToolCollection
      */
     private $items = [];
 
-    public function __construct(ContainerInterface $container, Reader $annotationReader)
+    public function __construct(ContainerInterface $container, ?Reader $annotationReader = null)
     {
         $this->container = $container;
         $this->annotationReader = $annotationReader;
+
+        if (null !== $annotationReader) {
+            trigger_deprecation('liip/test-fixtures-bundle', '2.5', 'Passing a "%s" to the "%s" constructor is deprecated.', Reader::class, self::class);
+        }
     }
 
     public function add(AbstractDatabaseTool $databaseTool): void


### PR DESCRIPTION
This PR makes three changes:

1) The `Liip\TestFixturesBundle\Services\DatabaseToolCollection` class requires providing a `Doctrine\Common\Annotations\Reader`, but this dependency is unused.  Passing a reader into the class is therefore deprecated and the argument is made optional.

2) The `doctrine/annotations` package got a 2.0 release.  Though it'll be a little bit before it can be installed alongside this package (the DoctrineBundle and PHPCR-ODM need releases supporting 2.0 first), the only reference to it in this package is the unused argument in the `Liip\TestFixturesBundle\Services\DatabaseToolCollection` constructor.  So, there should be no reason to block it when available.

3) Moves the `doctrine/annotations` package to be a dev dependency.  Since its only reference is an unused argument, there's no reason to require it to be installed.