### PR TITLE
disallow doctrine/annotations 2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,7 +88,7 @@ jobs:
 
       # This is needed to fix builds on Symfony 5.4 where the `annotation_reader` service may not be set up if the Annotations package is not in the production dependencies
       - name: Move Annotations to require
-        run: composer require --no-update "doctrine/annotations:^1.2.7|^2.0"
+        run: composer require --no-update "doctrine/annotations:^1.2.7"
 
       - name: Install Composer dependencies
         if: matrix.composer-flags == ''


### PR DESCRIPTION
This is a test to try to fix the error on CI:

```
Run php ./vendor/bin/phpunit --testdox --exclude-group ""
PHPUnit 9.5.27 by Sebastian Bergmann and contributors.

Error in bootstrap script: Error:
Call to undefined method Doctrine\Common\Annotations\AnnotationRegistry::registerLoader()
#0 /home/runner/work/LiipTestFixturesBundle/LiipTestFixturesBundle/vendor/phpunit/phpunit/src/Util/FileLoader.php(66): include_once()
#1 /home/runner/work/LiipTestFixturesBundle/LiipTestFixturesBundle/vendor/phpunit/phpunit/src/Util/FileLoader.php(49): PHPUnit\Util\FileLoader::load()
#2 /home/runner/work/LiipTestFixturesBundle/LiipTestFixturesBundle/vendor/phpunit/phpunit/src/TextUI/Command.php(565): PHPUnit\Util\FileLoader::checkAndLoad()
#3 /home/runner/work/LiipTestFixturesBundle/LiipTestFixturesBundle/vendor/phpunit/phpunit/src/TextUI/Command.php(345): PHPUnit\TextUI\Command->handleBootstrap()
#4 /home/runner/work/LiipTestFixturesBundle/LiipTestFixturesBundle/vendor/phpunit/phpunit/src/TextUI/Command.php(112): PHPUnit\TextUI\Command->handleArguments()
#5 /home/runner/work/LiipTestFixturesBundle/LiipTestFixturesBundle/vendor/phpunit/phpunit/src/TextUI/Command.php(97): PHPUnit\TextUI\Command->run()
#6 /home/runner/work/LiipTestFixturesBundle/LiipTestFixturesBundle/vendor/phpunit/phpunit/phpunit(98): PHPUnit\TextUI\Command::main()
#7 /home/runner/work/LiipTestFixturesBundle/LiipTestFixturesBundle/vendor/bin/phpunit(123): include('...')
#8 {main}
Error: Process completed with exit code 1.
```

Source: https://github.com/liip/LiipTestFixturesBundle/actions/runs/3821566891/jobs/6500840216#step:12:12