### PR TITLE
feat: remove unnecessary (duplicated) interfaces

### DIFF
--- a/src/Services/DatabaseBackup/MongodbDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/MongodbDatabaseBackup.php
@@ -20,7 +20,7 @@ use MongoDB\Driver\Server;
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-final class MongodbDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
+final class MongodbDatabaseBackup extends AbstractDatabaseBackup
 {
     protected static $referenceData;
 

--- a/src/Services/DatabaseBackup/MysqlDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/MysqlDatabaseBackup.php
@@ -20,7 +20,7 @@ use Doctrine\ORM\Tools\SchemaTool;
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-final class MysqlDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
+final class MysqlDatabaseBackup extends AbstractDatabaseBackup
 {
     protected static $metadata;
 

--- a/src/Services/DatabaseBackup/SqliteDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/SqliteDatabaseBackup.php
@@ -21,7 +21,7 @@ use InvalidArgumentException;
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-final class SqliteDatabaseBackup extends AbstractDatabaseBackup implements DatabaseBackupInterface
+final class SqliteDatabaseBackup extends AbstractDatabaseBackup
 {
     public function getBackupFilePath(): string
     {

--- a/tests/App/DataFixtures/ORM/LoadSecondUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadSecondUserData.php
@@ -14,18 +14,16 @@ declare(strict_types=1);
 namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
-use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
 
-class LoadSecondUserData extends AbstractFixture implements FixtureInterface
+class LoadSecondUserData extends AbstractFixture
 {
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var User $user */
         $user = new User();
         $user->setName('bar foo');
         $user->setEmail('bar@foo.com');

--- a/tests/App/DataFixtures/ORM/LoadUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserData.php
@@ -14,18 +14,16 @@ declare(strict_types=1);
 namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
-use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
 
-class LoadUserData extends AbstractFixture implements FixtureInterface
+class LoadUserData extends AbstractFixture
 {
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var User $user */
         $user = new User();
         $user->setId(1);
         $user->setName('foo bar');

--- a/tests/App/DataFixtures/ORM/LoadUserDataInGroup.php
+++ b/tests/App/DataFixtures/ORM/LoadUserDataInGroup.php
@@ -15,21 +15,19 @@ namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
 use Doctrine\Bundle\FixturesBundle\FixtureGroupInterface;
 use Doctrine\Common\DataFixtures\AbstractFixture;
-use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
 
 /**
  * @see \Liip\Acme\Tests\Test\ConfigSqliteTest::loadAllFixtures()
  */
-class LoadUserDataInGroup extends AbstractFixture implements FixtureInterface, FixtureGroupInterface
+class LoadUserDataInGroup extends AbstractFixture implements FixtureGroupInterface
 {
     /**
      * {@inheritdoc}
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var User $user */
         $user = new User();
         $user->setId(1);
         $user->setName('foo bar');

--- a/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserWithServiceData.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Liip\Acme\Tests\App\DataFixtures\ORM;
 
 use Doctrine\Common\DataFixtures\AbstractFixture;
-use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Persistence\ObjectManager;
 use Liip\Acme\Tests\App\Entity\User;
 use Liip\Acme\Tests\App\Service\DummyService;
@@ -22,7 +21,7 @@ use Liip\Acme\Tests\App\Service\DummyService;
 /**
  * @see LoadDependentUserWithServiceData::getDependencies()
  */
-class LoadUserWithServiceData extends AbstractFixture implements FixtureInterface
+class LoadUserWithServiceData extends AbstractFixture
 {
     /** @var DummyService */
     private $dummyService;
@@ -37,7 +36,6 @@ class LoadUserWithServiceData extends AbstractFixture implements FixtureInterfac
      */
     public function load(ObjectManager $manager): void
     {
-        /** @var User $user */
         $user = new User();
         $user->setId(1);
         $user->setName('foo bar');


### PR DESCRIPTION
- remove PhpDoc comment for User (already derived from code)
- The extended classes have already implemented that interfaces

The failing test for php 7.2 was there before. And not relevant anymore.