### PR TITLE
chore: fix warning for phpunit 10 (static data providers)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ composer.lock
 vendor
 .php_cs.cache
 .phpunit.result.cache
+.phpunit.cache
 
 # Ignore files created during tests
 /cov/

--- a/tests/Test/ConfigEventsTest.php
+++ b/tests/Test/ConfigEventsTest.php
@@ -136,7 +136,7 @@ class ConfigEventsTest extends KernelTestCase
         $this->testLoadEmptyFixturesAndCheckEventsAreCalled($eventName, $methodName, $numberOfInvocations, false);
     }
 
-    public function fixturesEventsProvider(): array
+    public static function fixturesEventsProvider(): array
     {
         return [
             [LiipTestFixturesEvents::PRE_FIXTURE_BACKUP_RESTORE, 'preFixtureBackupRestore', 1],


### PR DESCRIPTION
add phpunit 10 cache-directory to .gitignore