### PR TITLE
chore: allow monolog/monolog v3 for require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
         "doctrine/phpcr-bundle": "^2.0.2",
         "doctrine/phpcr-odm": "^1.3",
         "jackalope/jackalope-doctrine-dbal": "^1.5",
-        "monolog/monolog": "^1.25.1 || ^2.0",
+        "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
         "phpunit/phpunit": "^8.0 || ^9.0 || ^10.0",
         "symfony/doctrine-bridge": "^4.4 || ^5.4 || ^6.0",
         "symfony/monolog-bridge": "^4.4 || ^5.4 || ^6.0",


### PR DESCRIPTION
I am not sure if this should be a seperate PR or be done in https://github.com/liip/LiipTestFixturesBundle/pull/229