### PR TITLE
chore: migrate and update php-cs-fixer 2 => 3

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: PHP-CS-Fixer
-        uses: docker://jakzal/phpqa:1.58.7-php7.4-alpine
+        uses: docker://jakzal/phpqa:1.80.0-php7.4-alpine
         with:
           args: php-cs-fixer --dry-run --diff --no-interaction --ansi fix
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .idea/
 composer.lock
 vendor
-.php_cs.cache
+.php-cs-fixer.cache
 .phpunit.result.cache
 .phpunit.cache
 

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -9,12 +9,14 @@ This source file is subject to the MIT license that is bundled
 with this source code in the file LICENSE.
 HEADER;
 
+
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__)
     ->notPath('/cache/')
 ;
 
-return PhpCsFixer\Config::create()
+$config = new PhpCsFixer\Config();
+return $config
     ->setFinder($finder)
     ->setRiskyAllowed(true)
     ->setRules([
@@ -28,18 +30,14 @@ return PhpCsFixer\Config::create()
         'header_comment' => [
             'header' => $header,
         ],
-        'no_extra_consecutive_blank_lines' => true,
+        'no_extra_blank_lines' => true,
         'no_php4_constructor' => true,
         'no_useless_else' => true,
         'no_useless_return' => true,
-        'ordered_imports' => true,
+        'ordered_imports' => [
+            'sort_algorithm' => 'alpha',
+        ],
         'phpdoc_order' => true,
-        '@PHP56Migration' => true,
-        '@PHP56Migration:risky' => true,
-        '@PHP70Migration' => true,
-        '@PHP70Migration:risky' => true,
-        '@PHP71Migration' => true,
-        '@PHP71Migration:risky' => true,
         'strict_comparison' => true,
         'strict_param' => true,
         'php_unit_strict' => true,

--- a/src/Services/DatabaseBackup/AbstractDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/AbstractDatabaseBackup.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Liip\TestFixturesBundle\Services\DatabaseBackup;
 
-use DateTime;
 use Liip\TestFixturesBundle\Services\FixturesLoaderFactory;
 use ReflectionClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -67,7 +66,7 @@ abstract class AbstractDatabaseBackup implements DatabaseBackupInterface
      */
     protected function isBackupUpToDate(string $backup): bool
     {
-        $backupLastModifiedDateTime = DateTime::createFromFormat('U', (string) filemtime($backup));
+        $backupLastModifiedDateTime = \DateTime::createFromFormat('U', (string) filemtime($backup));
 
         $loader = $this->fixturesLoaderFactory->getFixtureLoader($this->classNames);
 
@@ -90,7 +89,7 @@ abstract class AbstractDatabaseBackup implements DatabaseBackupInterface
      * @param string $class The fully qualified class name of the fixture class to
      *                      check modification date on
      */
-    protected function getFixtureLastModified($class): ?DateTime
+    protected function getFixtureLastModified($class): ?\DateTime
     {
         $lastModifiedDateTime = null;
 
@@ -98,7 +97,7 @@ abstract class AbstractDatabaseBackup implements DatabaseBackupInterface
         $classFileName = $reflClass->getFileName();
 
         if (file_exists($classFileName)) {
-            $lastModifiedDateTime = new DateTime();
+            $lastModifiedDateTime = new \DateTime();
             $lastModifiedDateTime->setTimestamp(filemtime($classFileName));
         }
 

--- a/src/Services/DatabaseBackup/AbstractDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/AbstractDatabaseBackup.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Liip\TestFixturesBundle\Services\DatabaseBackup;
 
 use Liip\TestFixturesBundle\Services\FixturesLoaderFactory;
-use ReflectionClass;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -93,7 +92,7 @@ abstract class AbstractDatabaseBackup implements DatabaseBackupInterface
     {
         $lastModifiedDateTime = null;
 
-        $reflClass = new ReflectionClass($class);
+        $reflClass = new \ReflectionClass($class);
         $classFileName = $reflClass->getFileName();
 
         if (file_exists($classFileName)) {

--- a/src/Services/DatabaseBackup/SqliteDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/SqliteDatabaseBackup.php
@@ -16,7 +16,6 @@ namespace Liip\TestFixturesBundle\Services\DatabaseBackup;
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManager;
-use InvalidArgumentException;
 
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
@@ -71,7 +70,7 @@ final class SqliteDatabaseBackup extends AbstractDatabaseBackup implements Datab
 
         $name = $params['path'] ?? ($params['dbname'] ?? false);
         if (!$name) {
-            throw new InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");
+            throw new \InvalidArgumentException("Connection does not contain a 'path' or 'dbname' parameter and cannot be dropped.");
         }
 
         return $name;

--- a/src/Services/DatabaseTools/AbstractDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDatabaseTool.php
@@ -19,7 +19,6 @@ use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\DBAL\Connection;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
-use InvalidArgumentException;
 use Liip\TestFixturesBundle\Services\DatabaseBackup\DatabaseBackupInterface;
 use Liip\TestFixturesBundle\Services\FixturesLoaderFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -219,7 +218,7 @@ abstract class AbstractDatabaseTool
     /**
      * Locate fixture files.
      *
-     * @throws InvalidArgumentException if a wrong path is given outside a bundle
+     * @throws \InvalidArgumentException if a wrong path is given outside a bundle
      */
     protected function locateResources(array $paths): array
     {
@@ -230,7 +229,7 @@ abstract class AbstractDatabaseTool
         foreach ($paths as $path) {
             if ('@' !== $path[0]) {
                 if (!file_exists($path)) {
-                    throw new InvalidArgumentException(sprintf('Unable to find file "%s".', $path));
+                    throw new \InvalidArgumentException(sprintf('Unable to find file "%s".', $path));
                 }
                 $files[] = $path;
 

--- a/src/Services/DatabaseTools/AbstractDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDatabaseTool.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Liip\TestFixturesBundle\Services\DatabaseTools;
 
-use BadMethodCallException;
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
 use Doctrine\DBAL\Connection;
@@ -167,13 +166,13 @@ abstract class AbstractDatabaseTool
     }
 
     /**
-     * @throws BadMethodCallException
+     * @throws \BadMethodCallException
      */
     public function loadAliceFixture(array $paths = [], bool $append = false): array
     {
         $persisterLoaderServiceName = 'fidry_alice_data_fixtures.loader.doctrine';
         if (!$this->container->has($persisterLoaderServiceName)) {
-            throw new BadMethodCallException('theofidry/alice-data-fixtures must be installed to use this method.');
+            throw new \BadMethodCallException('theofidry/alice-data-fixtures must be installed to use this method.');
         }
 
         if (false === $append) {

--- a/tests/AppConfigPhpcr/DataFixtures/PHPCR/LoadTaskData.php
+++ b/tests/AppConfigPhpcr/DataFixtures/PHPCR/LoadTaskData.php
@@ -16,9 +16,7 @@ namespace Liip\Acme\Tests\AppConfigPhpcr\DataFixtures\PHPCR;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\ODM\PHPCR\DocumentManager;
 use Doctrine\Persistence\ObjectManager;
-use Exception;
 use Liip\Acme\Tests\AppConfigPhpcr\Document\Task;
-use RuntimeException;
 
 class LoadTaskData implements FixtureInterface
 {
@@ -27,13 +25,13 @@ class LoadTaskData implements FixtureInterface
         if (!$manager instanceof DocumentManager) {
             $class = \get_class($manager);
 
-            throw new RuntimeException("Fixture requires a PHPCR ODM DocumentManager instance, instance of '{$class}' given.");
+            throw new \RuntimeException("Fixture requires a PHPCR ODM DocumentManager instance, instance of '{$class}' given.");
         }
 
         $rootTask = $manager->find(null, '/');
 
         if (!$rootTask) {
-            throw new Exception('Could not find / document!');
+            throw new \Exception('Could not find / document!');
         }
 
         $task = new Task();

--- a/tests/Test/ConfigEventsTest.php
+++ b/tests/Test/ConfigEventsTest.php
@@ -31,7 +31,9 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  * So it must be loaded in a separate process.
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
+ *
  * @IgnoreAnnotation("dataProvider")
  *
  * @internal

--- a/tests/Test/ConfigMysqlCacheDbTest.php
+++ b/tests/Test/ConfigMysqlCacheDbTest.php
@@ -32,7 +32,9 @@ use Liip\Acme\Tests\AppConfigMysqlCacheDb\AppConfigMysqlKernelCacheDb;
  * So it must be loaded in a separate process.
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
+ *
  * @IgnoreAnnotation("group")
  *
  * @internal

--- a/tests/Test/ConfigMysqlKeepDatabaseAndSchemaTest.php
+++ b/tests/Test/ConfigMysqlKeepDatabaseAndSchemaTest.php
@@ -31,7 +31,9 @@ use Liip\Acme\Tests\AppConfigMysqlKeepDatabaseAndSchema\AppConfigMysqlKernelKeep
  * So it must be loaded in a separate process.
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
+ *
  * @IgnoreAnnotation("group")
  *
  * @internal

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -45,7 +45,9 @@ if (interface_exists('\Doctrine\Persistence\ObjectManager')
  * So it must be loaded in a separate process.
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
+ *
  * @IgnoreAnnotation("group")
  *
  * @internal

--- a/tests/Test/ConfigMysqlUrlTest.php
+++ b/tests/Test/ConfigMysqlUrlTest.php
@@ -30,6 +30,7 @@ use Liip\Acme\Tests\AppConfigMysqlUrl\AppConfigMysqlUrlKernel;
  * So it must be loaded in a separate process.
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
  *
  * @internal

--- a/tests/Test/ConfigPgsqlTest.php
+++ b/tests/Test/ConfigPgsqlTest.php
@@ -31,6 +31,7 @@ use Liip\TestFixturesBundle\Services\DatabaseTools\ORMDatabaseTool;
  * So it must be loaded in a separate process.
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
  *
  * @internal

--- a/tests/Test/ConfigPhpcrTest.php
+++ b/tests/Test/ConfigPhpcrTest.php
@@ -33,6 +33,7 @@ use Symfony\Component\Console\Tester\CommandTester;
  * So it must be loaded in a separate process.
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
  *
  * @internal

--- a/tests/Test/ConfigSqliteTest.php
+++ b/tests/Test/ConfigSqliteTest.php
@@ -22,7 +22,6 @@ if (interface_exists('\Doctrine\Persistence\ObjectManager')
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\Persistence\ObjectRepository;
-use InvalidArgumentException;
 use Liip\Acme\Tests\App\Entity\User;
 use Liip\Acme\Tests\AppConfigSqlite\AppConfigSqliteKernel;
 use Liip\Acme\Tests\Traits\ContainerProvider;
@@ -33,6 +32,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
  *
  * @IgnoreAnnotation("depends")
@@ -348,7 +348,7 @@ class ConfigSqliteTest extends KernelTestCase
      */
     public function testLoadNonexistentFixturesFiles(): void
     {
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->databaseTool->loadAliceFixture([
             '@AcmeBundle/DataFixtures/ORM/nonexistent.yml',
@@ -458,7 +458,7 @@ class ConfigSqliteTest extends KernelTestCase
     {
         $path = ['/nonexistent.yml'];
 
-        $this->expectException(InvalidArgumentException::class);
+        $this->expectException(\InvalidArgumentException::class);
 
         $this->databaseTool->loadAliceFixture($path);
     }

--- a/tests/Test/ConfigSqliteUrlTest.php
+++ b/tests/Test/ConfigSqliteUrlTest.php
@@ -26,6 +26,7 @@ use Liip\Acme\Tests\AppConfigSqliteUrl\AppConfigSqliteUrlKernel;
  * Run SQLite tests by using an URL for Doctrine.
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
  *
  * @IgnoreAnnotation("depends")

--- a/tests/Test/ConfigTest.php
+++ b/tests/Test/ConfigTest.php
@@ -38,6 +38,7 @@ use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
  * So it must be loaded in a separate process.
  *
  * @runTestsInSeparateProcesses
+ *
  * @preserveGlobalState disabled
  *
  * Avoid conflict with PHPUnit annotation when reading QueryCount
@@ -144,7 +145,7 @@ class ConfigTest extends KernelTestCase
         /** @var User $user1 */
         $user1 = $this->userRepository->findOneBy(['id' => 1]);
 
-        //The salt are not the same because cache were not used
+        // The salt are not the same because cache were not used
         $this->assertNotSame($user1Salt, $user1->getSalt());
 
         // Enable the cache again


### PR DESCRIPTION
I followed this guide for migration.
https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/blob/master/UPGRADE-v3.md

And updated phpqa
https://github.com/jakzal/phpqa

@alexislefebvre now i have some failing php-cs-fixer rules.

a) I can adjust the rules (i do not know the correct rules)

b) Change the code as suggested by php-cs-fixer
https://github.com/Chris53897/LiipTestFixturesBundle/actions/runs/5120788649/jobs/9207717351

WDYT?