### PR TITLE
Replace uses of deprecated `Connection::query()` method

### DIFF
--- a/src/Services/DatabaseBackup/MysqlDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/MysqlDatabaseBackup.php
@@ -84,7 +84,12 @@ final class MysqlDatabaseBackup extends AbstractDatabaseBackup
         $em = $executor->getReferenceRepository()->getManager();
         $connection = $em->getConnection();
 
-        $connection->query('SET FOREIGN_KEY_CHECKS = 0;');
+        if (method_exists($connection, 'executeQuery')) {
+            $connection->executeQuery('SET FOREIGN_KEY_CHECKS = 0;');
+        } else {
+            $connection->query('SET FOREIGN_KEY_CHECKS = 0;');
+        }
+
         $this->updateSchemaIfNeed($em);
         $truncateSql = [];
         foreach ($this->metadatas as $classMetadata) {
@@ -95,17 +100,29 @@ final class MysqlDatabaseBackup extends AbstractDatabaseBackup
             }
         }
         if (!empty($truncateSql)) {
-            $connection->query(implode(';', $truncateSql));
+            if (method_exists($connection, 'executeQuery')) {
+                $connection->executeQuery(implode(';', $truncateSql));
+            } else {
+                $connection->query(implode(';', $truncateSql));
+            }
         }
 
         // Only run query if it exists, to avoid the following exception:
         // SQLSTATE[42000]: Syntax error or access violation: 1065 Query was empty
         $backup = $this->getBackup();
         if (!empty($backup)) {
-            $connection->query($backup);
+            if (method_exists($connection, 'executeQuery')) {
+                $connection->executeQuery($backup);
+            } else {
+                $connection->query($backup);
+            }
         }
 
-        $connection->query('SET FOREIGN_KEY_CHECKS = 1;');
+        if (method_exists($connection, 'executeQuery')) {
+            $connection->executeQuery('SET FOREIGN_KEY_CHECKS = 1;');
+        } else {
+            $connection->query('SET FOREIGN_KEY_CHECKS = 1;');
+        }
 
         if (self::$metadata) {
             // it need for better performance

--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -212,7 +212,12 @@ class ORMDatabaseTool extends AbstractDatabaseTool
             return;
         }
 
-        $this->connection->query('SET FOREIGN_KEY_CHECKS=0');
+        if (method_exists($this->connection, 'executeQuery')) {
+            $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=0');
+        } else {
+            $this->connection->query('SET FOREIGN_KEY_CHECKS=0');
+        }
+
         $this->shouldEnableForeignKeyChecks = true;
     }
 
@@ -226,7 +231,12 @@ class ORMDatabaseTool extends AbstractDatabaseTool
             return;
         }
 
-        $this->connection->query('SET FOREIGN_KEY_CHECKS=1');
+        if (method_exists($this->connection, 'executeQuery')) {
+            $this->connection->executeQuery('SET FOREIGN_KEY_CHECKS=1');
+        } else {
+            $this->connection->query('SET FOREIGN_KEY_CHECKS=1');
+        }
+
         $this->shouldEnableForeignKeyChecks = false;
     }
 

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -136,7 +136,12 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
             return;
         }
 
-        $this->connection->query('PRAGMA foreign_keys = 0');
+        if (method_exists($this->connection, 'executeQuery')) {
+            $this->connection->executeQuery('PRAGMA foreign_keys = 0');
+        } else {
+            $this->connection->query('PRAGMA foreign_keys = 0');
+        }
+
         $this->shouldEnableForeignKeyChecks = true;
     }
 
@@ -150,7 +155,12 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
             return;
         }
 
-        $this->connection->query('PRAGMA foreign_keys = 1');
+        if (method_exists($this->connection, 'executeQuery')) {
+            $this->connection->executeQuery('PRAGMA foreign_keys = 1');
+        } else {
+            $this->connection->query('PRAGMA foreign_keys = 1');
+        }
+
         $this->shouldEnableForeignKeyChecks = false;
     }
 


### PR DESCRIPTION
Fixes #238 by wrapping calls to the deprecated `Connection::query()` with a `method_exists()` check to instead call `Connection::executeQuery()` when the preferred API is available.