### PR TITLE
chore: fix installation of mysqldump on CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -67,6 +67,7 @@ jobs:
     steps:
       - name: Install mysqldump
         run: |
+          sudo apt update
           sudo apt install -y -q ${{ matrix.mysql-client }}
           mysqldump --version
 


### PR DESCRIPTION
Follow-up of #260 