### PR TITLE
tests: remove legacy code for "theofidry/alice-data-fixtures"

### DIFF
--- a/tests/Test/ConfigTest.php
+++ b/tests/Test/ConfigTest.php
@@ -13,12 +13,6 @@ declare(strict_types=1);
 
 namespace Liip\Acme\Tests\Test;
 
-// BC, needed by "theofidry/alice-data-fixtures: <1.3" not compatible with "doctrine/persistence: ^2.0"
-if (interface_exists('\Doctrine\Persistence\ObjectManager')
-    && !interface_exists('\Doctrine\Common\Persistence\ObjectManager')) {
-    class_alias('\Doctrine\Persistence\ObjectManager', '\Doctrine\Common\Persistence\ObjectManager');
-}
-
 use Doctrine\Common\Annotations\Annotation\IgnoreAnnotation;
 use Doctrine\Persistence\ObjectRepository;
 use Liip\Acme\Tests\App\Entity\User;


### PR DESCRIPTION
Maybe this can be removed after the minimum version is above 1.3
https://github.com/liip/LiipTestFixturesBundle/blob/2.x/composer.json#L42