### PR TITLE
feat: fix dbal deprecation for connection

### DIFF
--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -177,10 +177,12 @@ class ORMDatabaseTool extends AbstractDatabaseTool
         // “An exception occurred in driver: SQLSTATE[HY000] [1049] Unknown database 'test'”
 
         $tmpConnection = DriverManager::getConnection($params);
-        $tmpConnection->connect();
 
-        if (!\in_array($dbName, $tmpConnection->getSchemaManager()->listDatabases(), true)) {
-            $tmpConnection->getSchemaManager()->createDatabase($dbName);
+        try {
+            if (!\in_array($dbName, $tmpConnection->createSchemaManager()->listDatabases(), true)) {
+                $tmpConnection->createSchemaManager()->createDatabase($dbName);
+            }
+        } catch (\Doctrine\DBAL\Platforms\Exception\NotSupported $e) {
         }
 
         $tmpConnection->close();


### PR DESCRIPTION
https://github.com/liip/LiipTestFixturesBundle/issues/259

This fix does makes it possible, to use it with my bundle and orm3 dbal4
I got a NotSupported Exception with SQLite-Database.

Please have a look if changes are correct.