### PR TITLE
fix: Restore MongoDB ODM Connection support

### DIFF
--- a/src/Services/DatabaseTools/AbstractDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDatabaseTool.php
@@ -61,7 +61,10 @@ abstract class AbstractDatabaseTool
      */
     protected $om;
 
-    protected Connection $connection;
+    /**
+     * @var Connection
+     */
+    protected $connection;
 
     /**
      * @var int|null


### PR DESCRIPTION
Regarding https://github.com/liip/LiipTestFixturesBundle/issues/258

This PR partially reverts be3a0cd073e06d9ca059ec60a1b93664944c1ca7 and restores the type-hint to allow ODM connections.