### PR TITLE
refactor: MongoDB Integration + MongoDB Tests

### DIFF
--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -9,6 +9,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@master
+      - name: Delete composer files to avoid installing dependencies
+        run: rm -v composer.json composer.lock
       - name: PHP-CS-Fixer
         uses: docker://jakzal/phpqa:1.80.0-php7.4-alpine
         with:

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@master
       - name: Delete composer files to avoid installing dependencies
-        run: rm -v composer.json composer.lock
+        run: rm -v composer.json
       - name: PHP-CS-Fixer
         uses: docker://jakzal/phpqa:1.80.0-php7.4-alpine
         with:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -68,6 +68,10 @@ jobs:
             --health-retries 5
         ports:
           - 5432:5432
+      mongodb:
+        image: mongo:5
+        ports:
+          - 27017:27017
 
     steps:
       - name: Install mysqldump
@@ -75,6 +79,12 @@ jobs:
           sudo apt update
           sudo apt install -y -q ${{ matrix.mysql-client }}
           mysqldump --version
+
+      - name: Install mongodb database tools
+        run: |
+          wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian92-x86_64-100.3.1.deb
+          sudo apt install ./mongodb-database-tools-*.deb
+          rm -f mongodb-database-tools-*.deb
 
       - name: Checkout
         uses: actions/checkout@v4
@@ -119,7 +129,7 @@ jobs:
         run: composer show
 
       - name: Set up hosts file
-        run: echo '127.0.0.1 mariadb postgres' | sudo tee -a /etc/hosts
+        run: echo '127.0.0.1 mariadb postgres mongodb' | sudo tee -a /etc/hosts
 
       - name: Run tests
         # In phpunit.xml.dist, tests annotated with "@group mysql" are excluded, revert this

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,11 @@ RUN apt-get update \
         pdo_mysql \
         pdo_pgsql \
         pdo_sqlite \
+    && pecl install mongodb \
+    && docker-php-ext-enable mongodb \
+    && wget https://fastdl.mongodb.org/tools/db/mongodb-database-tools-debian92-x86_64-100.3.1.deb \
+    && apt install ./mongodb-database-tools-*.deb \
     && apt-get clean \
-    && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
+    && rm -rf mongodb-database-tools-*.deb /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
         "doctrine/data-fixtures": "^1.7",
         "doctrine/doctrine-bundle": "^2.11",
         "doctrine/doctrine-fixtures-bundle": "^3.5.1 || ^4.0",
+        "doctrine/mongodb-odm-bundle": "^4.2 || ^5.0",
         "doctrine/orm": "^2.7",
         "doctrine/phpcr-bundle": "^2.4.3 || ^3.0",
         "doctrine/phpcr-odm": "^1.7.2 || ^2.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,3 +29,8 @@ services:
         working_dir: /application
         volumes:
             - '.:/application'
+
+    mongodb:
+        image: mongo:5
+        ports:
+            - '27017:27017'

--- a/src/FixturesLoaderFactoryInterface.php
+++ b/src/FixturesLoaderFactoryInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Liip\TestFixturesBundle;
+
+use Doctrine\Common\DataFixtures\Loader;
+
+interface FixturesLoaderFactoryInterface
+{
+    /**
+     * Retrieve Doctrine DataFixtures loader.
+     */
+    public function getFixtureLoader(array $classNames): Loader;
+
+}

--- a/src/Resources/config/database_tools.xml
+++ b/src/Resources/config/database_tools.xml
@@ -9,6 +9,10 @@
             <argument type="service" id="service_container" />
             <argument type="service" id="doctrine.fixtures.loader" on-invalid="null"/>
         </service>
+        <service id="Liip\TestFixturesBundle\Services\MongoDBFixturesLoaderFactory" public="true">
+            <argument type="service" id="service_container" />
+            <argument type="service" id="doctrine_mongodb.odm.symfony.fixtures.loader" on-invalid="null"/>
+        </service>
 
         <service id="Liip\TestFixturesBundle\Services\DatabaseBackup\SqliteDatabaseBackup" public="true">
             <argument type="service" id="service_container" />
@@ -22,7 +26,7 @@
 
         <service id="Liip\TestFixturesBundle\Services\DatabaseBackup\MongodbDatabaseBackup" public="true">
             <argument type="service" id="service_container" />
-            <argument type="service" id="Liip\TestFixturesBundle\Services\FixturesLoaderFactory" />
+            <argument type="service" id="Liip\TestFixturesBundle\Services\MongoDBFixturesLoaderFactory" />
         </service>
 
         <service id="Liip\TestFixturesBundle\Services\DatabaseTools\ORMDatabaseTool" public="false">
@@ -35,7 +39,7 @@
         </service>
         <service id="Liip\TestFixturesBundle\Services\DatabaseTools\MongoDBDatabaseTool" public="false">
             <argument type="service" id="service_container" />
-            <argument type="service" id="Liip\TestFixturesBundle\Services\FixturesLoaderFactory" />
+            <argument type="service" id="Liip\TestFixturesBundle\Services\MongoDBFixturesLoaderFactory" />
         </service>
         <service id="Liip\TestFixturesBundle\Services\DatabaseTools\PHPCRDatabaseTool" public="false">
             <argument type="service" id="service_container" />

--- a/src/Services/DatabaseBackup/AbstractDatabaseBackup.php
+++ b/src/Services/DatabaseBackup/AbstractDatabaseBackup.php
@@ -13,7 +13,7 @@ declare(strict_types=1);
 
 namespace Liip\TestFixturesBundle\Services\DatabaseBackup;
 
-use Liip\TestFixturesBundle\Services\FixturesLoaderFactory;
+use Liip\TestFixturesBundle\FixturesLoaderFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
@@ -37,7 +37,7 @@ abstract class AbstractDatabaseBackup implements DatabaseBackupInterface
      */
     protected $classNames = [];
 
-    public function __construct(ContainerInterface $container, FixturesLoaderFactory $fixturesLoaderFactory)
+    public function __construct(ContainerInterface $container, FixturesLoaderFactoryInterface $fixturesLoaderFactory)
     {
         $this->container = $container;
         $this->fixturesLoaderFactory = $fixturesLoaderFactory;

--- a/src/Services/DatabaseTools/AbstractDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDatabaseTool.php
@@ -15,14 +15,10 @@ namespace Liip\TestFixturesBundle\Services\DatabaseTools;
 
 use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Common\DataFixtures\Executor\AbstractExecutor;
-use Doctrine\DBAL\Connection;
-use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
-use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
-use Doctrine\DBAL\Platforms\SqlitePlatform;
 use Doctrine\Persistence\ManagerRegistry;
 use Doctrine\Persistence\ObjectManager;
+use Liip\TestFixturesBundle\FixturesLoaderFactoryInterface;
 use Liip\TestFixturesBundle\Services\DatabaseBackup\DatabaseBackupInterface;
-use Liip\TestFixturesBundle\Services\FixturesLoaderFactory;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -39,7 +35,7 @@ abstract class AbstractDatabaseTool
     /** @var EventDispatcherInterface */
     protected $eventDispatcher;
 
-    protected $fixturesLoaderFactory;
+    protected FixturesLoaderFactoryInterface $fixturesLoaderFactory;
 
     /**
      * @var ManagerRegistry
@@ -61,8 +57,6 @@ abstract class AbstractDatabaseTool
      */
     protected $om;
 
-    protected Connection $connection;
-
     /**
      * @var int|null
      */
@@ -80,7 +74,7 @@ abstract class AbstractDatabaseTool
      */
     private static $cachedMetadatas = [];
 
-    public function __construct(ContainerInterface $container, FixturesLoaderFactory $fixturesLoaderFactory)
+    public function __construct(ContainerInterface $container, FixturesLoaderFactoryInterface $fixturesLoaderFactory)
     {
         $this->container = $container;
         $this->eventDispatcher = $container->get('event_dispatcher');
@@ -106,7 +100,6 @@ abstract class AbstractDatabaseTool
     {
         $this->omName = $omName;
         $this->om = $this->registry->getManager($omName);
-        $this->connection = $this->registry->getConnection($omName);
     }
 
     public function setRegistryName(string $registryName): void
@@ -271,18 +264,5 @@ abstract class AbstractDatabaseTool
             && false !== $this->container->getParameter(self::CACHE_METADATA_PARAMETER_NAME);
     }
 
-    private function getPlatformName(): string
-    {
-        $platform = $this->connection->getDatabasePlatform();
-
-        if ($platform instanceof AbstractMySQLPlatform) {
-            return 'mysql';
-        } elseif ($platform instanceof SqlitePlatform) {
-            return 'sqlite';
-        } elseif ($platform instanceof PostgreSQLPlatform) {
-            return 'pgsql';
-        }
-
-        return (new \ReflectionClass($platform))->getShortName();
-    }
+    abstract protected function getPlatformName(): string;
 }

--- a/src/Services/DatabaseTools/AbstractDbalDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDbalDatabaseTool.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/TestFixturesBundle
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\TestFixturesBundle\Services\DatabaseTools;
+
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
+use Doctrine\DBAL\Platforms\SqlitePlatform;
+
+abstract class AbstractDbalDatabaseTool extends AbstractDatabaseTool
+{
+    protected Connection $connection;
+
+    public function setObjectManagerName(string $omName = null): void
+    {
+        parent::setObjectManagerName($omName);
+        $this->connection = $this->registry->getConnection($omName);
+    }
+
+    protected function getPlatformName(): string
+    {
+        $platform = $this->connection->getDatabasePlatform();
+
+        if ($platform instanceof AbstractMySQLPlatform) {
+            return 'mysql';
+        } elseif ($platform instanceof SqlitePlatform) {
+            return 'sqlite';
+        } elseif ($platform instanceof PostgreSQLPlatform) {
+            return 'pgsql';
+        }
+
+        return parent::getPlatformName();
+    }
+}

--- a/src/Services/DatabaseTools/MongoDBDatabaseTool.php
+++ b/src/Services/DatabaseTools/MongoDBDatabaseTool.php
@@ -119,4 +119,9 @@ class MongoDBDatabaseTool extends AbstractDatabaseTool
             self::$databaseCreated = true;
         }
     }
+
+    protected function getPlatformName(): string
+    {
+        return 'mongodb';
+    }
 }

--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -31,7 +31,7 @@ use Liip\TestFixturesBundle\LiipTestFixturesEvents;
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-class ORMDatabaseTool extends AbstractDatabaseTool
+class ORMDatabaseTool extends AbstractDbalDatabaseTool
 {
     /**
      * @var EntityManager

--- a/src/Services/DatabaseTools/PHPCRDatabaseTool.php
+++ b/src/Services/DatabaseTools/PHPCRDatabaseTool.php
@@ -119,4 +119,9 @@ class PHPCRDatabaseTool extends AbstractDatabaseTool
 
         return $this->container->has($serviceName) ? $this->container->get($serviceName) : null;
     }
+
+    protected function getPlatformName(): string
+    {
+        return 'phpcr';
+    }
 }

--- a/src/Services/MongoDBFixturesLoaderFactory.php
+++ b/src/Services/MongoDBFixturesLoaderFactory.php
@@ -2,26 +2,14 @@
 
 declare(strict_types=1);
 
-/*
- * This file is part of the Liip/TestFixturesBundle
- *
- * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
- *
- * This source file is subject to the MIT license that is bundled
- * with this source code in the file LICENSE.
- */
-
 namespace Liip\TestFixturesBundle\Services;
 
-use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
+use Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Common\DataFixtures\Loader;
 use Liip\TestFixturesBundle\FixturesLoaderFactoryInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
-/**
- * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
- */
-final class FixturesLoaderFactory implements FixturesLoaderFactoryInterface
+class MongoDBFixturesLoaderFactory implements FixturesLoaderFactoryInterface
 {
     private ContainerInterface $container;
 

--- a/src/Services/SymfonyFixturesLoaderWrapper.php
+++ b/src/Services/SymfonyFixturesLoaderWrapper.php
@@ -13,15 +13,14 @@ declare(strict_types=1);
 
 namespace Liip\TestFixturesBundle\Services;
 
-use Doctrine\Bundle\FixturesBundle\Loader\SymfonyFixturesLoader;
 use Doctrine\Common\DataFixtures\FixtureInterface;
 use Doctrine\Common\DataFixtures\Loader;
 
 final class SymfonyFixturesLoaderWrapper extends Loader
 {
-    private SymfonyFixturesLoader $symfonyFixturesLoader;
+    private Loader $symfonyFixturesLoader;
 
-    public function __construct(SymfonyFixturesLoader $symfonyFixturesLoader)
+    public function __construct(Loader $symfonyFixturesLoader)
     {
         $this->symfonyFixturesLoader = $symfonyFixturesLoader;
     }

--- a/tests/App/config/bundles.php
+++ b/tests/App/config/bundles.php
@@ -21,4 +21,5 @@ return [
     Liip\TestFixturesBundle\LiipTestFixturesBundle::class => ['all' => true],
     Liip\Acme\Tests\App\AcmeBundle::class => ['all' => true],
     Doctrine\Bundle\PHPCRBundle\DoctrinePHPCRBundle::class => ['phpcr' => true],
+    Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle::class => ['mongodb' => true],
 ];

--- a/tests/AppConfigMongodb/AppConfigMongodbKernel.php
+++ b/tests/AppConfigMongodb/AppConfigMongodbKernel.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/TestFixturesBundle
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\AppConfigMongodb;
+
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
+use Liip\Acme\Tests\AppConfig\AppConfigKernel;
+use Symfony\Component\Config\Loader\LoaderInterface;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+
+class AppConfigMongodbKernel extends AppConfigKernel
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function getCacheDir(): string
+    {
+        return __DIR__.'/var/cache/';
+    }
+
+    protected function configureContainer(ContainerBuilder $container, LoaderInterface $loader): void
+    {
+        // Load the default file.
+        parent::configureContainer($container, $loader);
+
+        // Load the file with MongoDB configuration
+        if (class_exists(DoctrineMongoDBBundle::class)) {
+            $loader->load(__DIR__.'/config.yml');
+        }
+    }
+}

--- a/tests/AppConfigMongodb/DataFixtures/MongoDB/LoadUserDataFixture.php
+++ b/tests/AppConfigMongodb/DataFixtures/MongoDB/LoadUserDataFixture.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/TestFixturesBundle
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\AppConfigMongodb\DataFixtures\MongoDB;
+
+use Doctrine\Bundle\MongoDBBundle\Fixture\Fixture;
+use Doctrine\ODM\MongoDB\DocumentManager;
+use Doctrine\Persistence\ObjectManager;
+use Liip\Acme\Tests\AppConfigMongodb\Document\User;
+
+class LoadUserDataFixture extends Fixture
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function load(ObjectManager $manager): void
+    {
+        if (!$manager instanceof DocumentManager) {
+            $class = \get_class($manager);
+
+            throw new \RuntimeException("Fixture requires a MongoDB ODM DocumentManager instance, instance of '{$class}' given.");
+        }
+        $user = new User();
+        $user->setName('foo bar');
+        $user->setEmail('foo@bar.com');
+
+        $manager->persist($user);
+        $manager->flush();
+
+        $this->addReference('user', $user);
+
+        $user = clone $this->getReference('user');
+
+        $manager->persist($user);
+        $manager->flush();
+    }
+}

--- a/tests/AppConfigMongodb/Document/User.php
+++ b/tests/AppConfigMongodb/Document/User.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/TestFixturesBundle
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\AppConfigMongodb\Document;
+
+use Doctrine\ODM\MongoDB\Mapping\Annotations as ODM;
+
+#[ODM\Document]
+class User
+{
+    #[ODM\Id]
+    private ?string $id = null;
+
+    #[ODM\Field(type: "string")]
+    private string $name;
+
+    #[ODM\Field(type: "string")]
+    private string $salt;
+
+    #[ODM\Field(type: "string")]
+    private string $email;
+
+    #[ODM\Field(type: "string")]
+    private ?string $dummyText = null;
+
+    public function __construct()
+    {
+        $this->salt = sha1(
+            // http://php.net/manual/fr/function.openssl-random-pseudo-bytes.php
+            bin2hex(openssl_random_pseudo_bytes(100))
+        );
+    }
+
+    public function getId(): string
+    {
+        return $this->id;
+    }
+
+    public function setName(string $name): self
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function setEmail(string $email): self
+    {
+        $this->email = $email;
+
+        return $this;
+    }
+
+    public function getEmail(): string
+    {
+        return $this->email;
+    }
+
+    public function setSalt(string $salt): self
+    {
+        $this->salt = $salt;
+
+        return $this;
+    }
+
+    public function getSalt(): string
+    {
+        return $this->salt;
+    }
+
+    public function setDummyText(?string $dummyText): self
+    {
+        $this->dummyText = $dummyText;
+
+        return $this;
+    }
+
+    public function getDummyText(): ?string
+    {
+        return $this->dummyText;
+    }
+}

--- a/tests/AppConfigMongodb/config.yml
+++ b/tests/AppConfigMongodb/config.yml
@@ -1,0 +1,24 @@
+# inherits configuration from ../App/config.yml
+doctrine_mongodb:
+    connections:
+        default:
+            server: 'mongodb://mongodb:27017/test'
+            options: {}
+    document_managers:
+        default:
+            mappings:
+                LiipAcme:
+                    type: attribute
+                    dir: "%kernel.project_dir%/../AppConfigMongodb/Document"
+                    prefix: 'Liip\Acme\Tests\AppConfigMongodb\Document'
+                    is_bundle: false
+
+services:
+    _defaults:
+        autowire: true
+        autoconfigure: true
+        public: false
+    
+    Liip\Acme\Tests\AppConfigMongodb\:
+        resource: './*'
+        exclude: '{Document,*.php,var}'

--- a/tests/Test/ConfigMongodbTest.php
+++ b/tests/Test/ConfigMongodbTest.php
@@ -1,0 +1,117 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/TestFixturesBundle
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+
+use Doctrine\Bundle\MongoDBBundle\DoctrineMongoDBBundle;
+use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
+use Doctrine\ODM\MongoDB\Repository\DocumentRepository;
+use Liip\Acme\Tests\AppConfigMongodb\DataFixtures\MongoDB\LoadUserDataFixture;
+use Liip\Acme\Tests\AppConfigMongodb\AppConfigMongodbKernel;
+use Liip\Acme\Tests\AppConfigMongodb\Document\User;
+use Liip\Acme\Tests\Traits\ContainerProvider;
+use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
+use Liip\TestFixturesBundle\Services\DatabaseTools\AbstractDatabaseTool;
+use Liip\TestFixturesBundle\Services\DatabaseTools\MongoDBDatabaseTool;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Test MongoDB.
+ *
+ * Use Tests/AppConfigMongodb/AppConfigMongodbKernel.php instead of
+ * Tests/App/AppKernel.php.
+ * So it must be loaded in a separate process.
+ *
+ * @#runTestsInSeparateProcesses
+ *
+ * @preserveGlobalState disabled
+ *
+ * @internal
+ */
+class ConfigMongodbTest extends KernelTestCase
+{
+    use ContainerProvider;
+
+    /** @var AbstractDatabaseTool */
+    protected $databaseTool;
+    
+    private DocumentRepository $userRepository;
+
+    protected function setUp(): void
+    {
+        if (!class_exists(DoctrineMongoDBBundle::class)) {
+            $this->markTestSkipped('Need doctrine/mongodb-odm-bundle package.');
+        }
+        if (version_compare(PHP_VERSION, '8.1.0') < 0) {
+            $this->markTestSkipped('MongoDB Tests doesn\'t support Outdated PHP Version. <8.1.0');
+        }
+
+        parent::setUp();
+
+        self::bootKernel([
+            'environment' => 'mongodb',
+        ]);
+
+        $this->userRepository = $this->getTestContainer()->get('doctrine_mongodb')
+            ->getRepository(User::class);
+        
+        $this->databaseTool = $this->getTestContainer()->get(DatabaseToolCollection::class)->get('default', 'doctrine_mongodb');
+
+        $this->assertInstanceOf(MongoDBDatabaseTool::class, $this->databaseTool);
+    }
+
+    public function testLoadFixturesMongodb(): void
+    {
+        $fixtures = $this->databaseTool->loadFixtures([
+            LoadUserDataFixture::class,
+        ]);
+
+        $this->assertInstanceOf(
+            \Doctrine\Common\DataFixtures\Executor\MongoDBExecutor::class,
+            $fixtures
+        );
+
+        $repository = $fixtures->getReferenceRepository();
+
+        $this->assertInstanceOf(
+            ProxyReferenceRepository::class,
+            $repository
+        );
+
+        $user1 = $repository->getReference('user');
+
+        $this->assertSame('foo bar', $user1->getName());
+        $this->assertSame('foo@bar.com', $user1->getEmail());
+
+        // Load data from database
+        /** @var User $user */
+        $user = $this->userRepository
+            ->findOneBy([
+                'email' => 'foo@bar.com',
+            ])
+        ;
+
+        $this->assertSame(
+            'foo@bar.com',
+            $user->getEmail()
+        );
+    }
+
+    protected static function getKernelClass(): string
+    {
+        return AppConfigMongodbKernel::class;
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        unset($this->databaseTool);
+    }
+}


### PR DESCRIPTION
Regarding #258 (replaces #273 by my colleague @buffcode)

`AbstractDatabaseTool` is split to extract DBAL specific code, such that using `MongoDBDatabaseTool` doesn't fail anymore.

As requested test for the MongoDB-Integration are added. To make this work, I also needed to fix a the usage of `SymfonyFixturesLoader`.
MongoDB-Fixtures extend a different base class then ORM fixtures and are tagged differently by Symfony. They are accessed by a different `SymfonyFixturesLoader` (`Doctrine\Bundle\MongoDBBundle\Loader\SymfonyFixturesLoader`).

This also removes the need for a workaround we had to use in our codebase to make use of `MongoDBDatabaseTool` (before it broke with 2.7.2).
```php
        // Reihenfolge relevant, da wir die Fixtures manuell hinzufügen müssen
        $fixtures = [
            CountryFixture::class,
            TaxAuthorityFixture::class,
            // ...
        ];

        // Fixture Loader lädt nur ORM Fixtures und LiipTestBundle nutzt nicht den ODM Fixture Loader.
        // Daher ergänzen wir den Loader um die ODM Fixtures.
        $fixturesLoader = static::getContainer()->get('doctrine.fixtures.loader');
        foreach ($fixtures as $fixture) {
            $fixturesLoader->addFixture(new $fixture());
        }

        // add all your fixtures classes that implement
        // Doctrine\Common\DataFixtures\FixtureInterface
        $this->databaseTool = static::getContainer()->get(DatabaseToolCollection::class)->get(null, 'doctrine_mongodb');
        $this->databaseTool->loadFixtures($fixtures);
```