### PR TITLE
[2.x] Update minimum versions for optional dependencies and fix DBAL 2.x compat

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,12 +25,14 @@
         "symfony/yaml": "^5.4 || ^6.3 || ^7.0"
     },
     "require-dev": {
-        "doctrine/annotations": "^1.8.0 || ^2.0",
-        "doctrine/data-fixtures": "^1.7",
-        "doctrine/doctrine-bundle": "^2.11",
-        "doctrine/doctrine-fixtures-bundle": "^3.5.1 || ^4.0",
-        "doctrine/mongodb-odm-bundle": "^4.2 || ^5.0",
-        "doctrine/orm": "^2.7",
+        "doctrine/annotations": "^1.13.1 || ^2.0",
+        "doctrine/data-fixtures": "^1.4.4",
+        "doctrine/dbal": "^2.13.1 || ^3.1",
+        "doctrine/doctrine-bundle": "^2.2",
+        "doctrine/doctrine-fixtures-bundle": "^3.4.4 || ^4.0",
+        "doctrine/mongodb-odm": "^2.2",
+        "doctrine/mongodb-odm-bundle": "^4.2.1 || ^5.0",
+        "doctrine/orm": "^2.14",
         "doctrine/phpcr-bundle": "^2.4.3 || ^3.0",
         "doctrine/phpcr-odm": "^1.7.2 || ^2.0",
         "jackalope/jackalope-doctrine-dbal": "^1.10.1 || ^2.0",
@@ -43,8 +45,10 @@
         "theofidry/alice-data-fixtures": "^1.5.2"
     },
     "conflict": {
-        "doctrine/annotations": "<1.2.7 || >=3.0",
-        "doctrine/dbal": "<2.11"
+        "doctrine/annotations": "<1.13.1 || >=3.0",
+        "doctrine/dbal": "<2.13.1 || ~3.0.0 || >=4.0",
+        "doctrine/mongodb-odm": "<2.2 || >=3.0",
+        "doctrine/orm": "<2.14 || >=3.0"
     },
     "suggest": {
         "doctrine/dbal": "Required when using the fixture loading functionality with an ORM and SQLite",

--- a/src/Services/DatabaseTools/AbstractDbalDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDbalDatabaseTool.php
@@ -15,6 +15,7 @@ namespace Liip\TestFixturesBundle\Services\DatabaseTools;
 
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Platforms\AbstractMySQLPlatform;
+use Doctrine\DBAL\Platforms\MySqlPlatform;
 use Doctrine\DBAL\Platforms\PostgreSQLPlatform;
 use Doctrine\DBAL\Platforms\SqlitePlatform;
 
@@ -32,7 +33,8 @@ abstract class AbstractDbalDatabaseTool extends AbstractDatabaseTool
     {
         $platform = $this->connection->getDatabasePlatform();
 
-        if ($platform instanceof AbstractMySQLPlatform) {
+        // AbstractMySQLPlatform was introduced in DBAL 3.3, keep the MySQLPlatform checks for compatibility with older versions
+        if ($platform instanceof AbstractMySQLPlatform || $platform instanceof MySqlPlatform) {
             return 'mysql';
         } elseif ($platform instanceof SqlitePlatform) {
             return 'sqlite';
@@ -40,6 +42,6 @@ abstract class AbstractDbalDatabaseTool extends AbstractDatabaseTool
             return 'pgsql';
         }
 
-        return parent::getPlatformName();
+        return (new \ReflectionClass($platform))->getShortName();
     }
 }

--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -178,9 +178,16 @@ class ORMDatabaseTool extends AbstractDbalDatabaseTool
 
         $tmpConnection = DriverManager::getConnection($params);
 
+        if (method_exists($tmpConnection, 'createSchemaManager')) {
+            $schemaManager = $tmpConnection->createSchemaManager();
+        } else {
+            $schemaManager = $tmpConnection->getSchemaManager();
+        }
+
+        // DBAL 4.x does not support creating databases for SQLite anymore; for now we silently ignore this error
         try {
-            if (!\in_array($dbName, $tmpConnection->createSchemaManager()->listDatabases(), true)) {
-                $tmpConnection->createSchemaManager()->createDatabase($dbName);
+            if (!\in_array($dbName, $schemaManager->listDatabases(), true)) {
+                $schemaManager->createDatabase($dbName);
             }
         } catch (\Doctrine\DBAL\Platforms\Exception\NotSupported $e) {
         }


### PR DESCRIPTION
Ref #276

I mostly based this on the output from https://github.com/liip/LiipTestFixturesBundle/actions/runs/8225016225/job/22489537505 (the `--prefer-lowest` run for the last merge on the 2.x branch) and info from `composer why` (notes inline with the diff).

Without getting into a massively complicated CI matrix where all of the optional integrations are stripped out and runs are made with only a single integration installed (i.e. a job where the ORM and MongoDB ODM are removed and only the PHPCR ODM kept, the two ODMs removed and only the ORM kept, etc.), this is the best that can be done for the moment.

3.x will need a similar PR after this one is reviewed and upmerged (sorry for the conflicts this will create 😅)