### PR TITLE
[3.x] fix: clean entity manager before loading fixtures

### DIFF
--- a/src/Services/DatabaseTools/AbstractDatabaseTool.php
+++ b/src/Services/DatabaseTools/AbstractDatabaseTool.php
@@ -170,6 +170,9 @@ abstract class AbstractDatabaseTool
 
         if (false === $append) {
             $this->cleanDatabase();
+
+            // Clear the entity manager to avoid the exception `EntityIdentityCollisionException`
+            $this->om->clear();
         }
 
         $files = $this->locateResources($paths);

--- a/src/Services/DatabaseTools/MongoDBDatabaseTool.php
+++ b/src/Services/DatabaseTools/MongoDBDatabaseTool.php
@@ -76,6 +76,9 @@ class MongoDBDatabaseTool extends AbstractDatabaseTool
         $executor->setReferenceRepository($referenceRepository);
         if (false === $append) {
             $executor->purge();
+
+            // Clear the entity manager to avoid the exception `EntityIdentityCollisionException`
+            $this->om->clear();
         }
 
         $loader = $this->fixturesLoaderFactory->getFixtureLoader($classNames);

--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -116,6 +116,9 @@ class ORMDatabaseTool extends AbstractDbalDatabaseTool
             $this->disableForeignKeyChecksIfApplicable();
             $executor->purge();
             $this->enableForeignKeyChecksIfApplicable();
+
+            // Clear the entity manager to avoid the exception `EntityIdentityCollisionException`
+            $this->om->clear();
         }
 
         $loader = $this->fixturesLoaderFactory->getFixtureLoader($classNames);

--- a/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMSqliteDatabaseTool.php
@@ -94,6 +94,9 @@ class ORMSqliteDatabaseTool extends ORMDatabaseTool
         $executor->setReferenceRepository($referenceRepository);
         if (false === $append) {
             $executor->purge();
+
+            // Clear the entity manager to avoid the exception `EntityIdentityCollisionException`
+            $this->om->clear();
         }
 
         $loader = $this->fixturesLoaderFactory->getFixtureLoader($classNames);

--- a/tests/App/DataFixtures/ORM/LoadUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadUserData.php
@@ -27,7 +27,6 @@ class LoadUserData extends AbstractFixture
         $user->setEmail('foo@bar.com');
 
         $manager->persist($user);
-        $manager->flush();
 
         $this->addReference('user', $user);
 

--- a/tests/AppConfigMongodb/DataFixtures/MongoDB/LoadUserDataFixture.php
+++ b/tests/AppConfigMongodb/DataFixtures/MongoDB/LoadUserDataFixture.php
@@ -32,13 +32,14 @@ class LoadUserDataFixture extends Fixture
         $user->setEmail('foo@bar.com');
 
         $manager->persist($user);
-        $manager->flush();
 
         $this->addReference('user', $user);
 
-        $user = clone $this->getReference('user');
+        $user2 = new User();
+        $user2->setName('alice bar');
+        $user2->setEmail('alice@bar.com');
 
-        $manager->persist($user);
+        $manager->persist($user2);
         $manager->flush();
     }
 }

--- a/tests/Test/ConfigMysqlCacheDbTest.php
+++ b/tests/Test/ConfigMysqlCacheDbTest.php
@@ -35,10 +35,15 @@ use PHPUnit\Framework\Attributes\PreserveGlobalState;
 #[PreserveGlobalState(false)]
 class ConfigMysqlCacheDbTest extends ConfigMysqlTest
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->assertTrue($this->databaseTool->isDatabaseCacheEnabled());
+    }
+
     public function testLoadFixturesAndCheckBackup(): void
     {
-        $this->assertTrue($this->databaseTool->isDatabaseCacheEnabled());
-
         $this->databaseTool->loadFixtures([
             'Liip\Acme\Tests\App\DataFixtures\ORM\LoadUserData',
         ]);

--- a/tests/Test/ConfigMysqlCacheDbTest.php
+++ b/tests/Test/ConfigMysqlCacheDbTest.php
@@ -110,21 +110,32 @@ class ConfigMysqlCacheDbTest extends ConfigMysqlTest
         );
     }
 
-    public function testLoadFixturesCheckReferences(): void
+    public function testLoadFixturesCheckReferencesByClass(): void
     {
         $this->markTestSkipped('This test is broken right now.');
+
         $referenceRepository = $this->databaseTool->loadFixtures([
             'Liip\Acme\Tests\App\DataFixtures\ORM\LoadUserData',
         ])->getReferenceRepository();
 
-        $this->assertCount(1, $referenceRepository->getReferences());
+        $references = $referenceRepository->getReferencesByClass();
+
+        $className = 'Liip\Acme\Tests\App\Entity\User';
+
+        $this->assertArrayHasKey($className, $references);
+
+        $this->assertCount(1, $references[$className]);
 
         $referenceRepository = $this->databaseTool->loadFixtures([
             'Liip\Acme\Tests\App\DataFixtures\ORM\LoadUserData',
             'Liip\Acme\Tests\App\DataFixtures\ORM\LoadSecondUserData',
         ])->getReferenceRepository();
 
-        $this->assertCount(2, $referenceRepository->getReferences());
+        $references = $referenceRepository->getReferencesByClass();
+
+        $this->assertArrayHasKey($className, $references);
+
+        $this->assertCount(2, $references[$className]);
     }
 
     protected static function getKernelClass(): string

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -249,8 +249,6 @@ class ConfigMysqlTest extends KernelTestCase
             $users
         );
 
-        $this->getTestContainer()->get('doctrine')->getManager()->clear();
-
         // Reload fixtures
         $this->databaseTool->loadFixtures([
             'Liip\Acme\Tests\App\DataFixtures\ORM\LoadUserData',

--- a/tests/Test/ConfigTest.php
+++ b/tests/Test/ConfigTest.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Liip\Acme\Tests\Test;
 
-use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\Persistence\ObjectRepository;
 use Liip\Acme\Tests\App\Entity\User;
 use Liip\Acme\Tests\AppConfig\AppConfigKernel;
@@ -45,7 +44,6 @@ class ConfigTest extends KernelTestCase
     private $userRepository;
     /** @var SqliteDatabaseBackup */
     private $sqliteDatabaseBackup;
-    private EntityManagerInterface $entityManager;
 
     protected function setUp(): void
     {
@@ -64,10 +62,6 @@ class ConfigTest extends KernelTestCase
         $this->sqliteDatabaseBackup = $this->getTestContainer()->get(SqliteDatabaseBackup::class);
 
         $this->assertInstanceOf(SqliteDatabaseBackup::class, $this->sqliteDatabaseBackup);
-
-        $this->entityManager = $this->getTestContainer()->get(EntityManagerInterface::class);
-
-        $this->assertInstanceOf(EntityManagerInterface::class, $this->entityManager);
     }
 
     /**
@@ -101,8 +95,6 @@ class ConfigTest extends KernelTestCase
             $user1->getName()
         );
 
-        $this->getTestContainer()->get('doctrine')->getManager()->clear();
-
         // Load Data Fixtures with custom loader defined in configuration.
         $fixtures = $this->databaseTool->loadAliceFixture([
             '@AcmeBundle/DataFixtures/ORM/user_with_custom_provider.yml',
@@ -130,9 +122,12 @@ class ConfigTest extends KernelTestCase
 
         $this->databaseTool->setDatabaseCacheEnabled(false);
 
+        // Cache is not up-to-date.
+        $this->assertFalse($this->databaseTool->isDatabaseCacheEnabled());
+
         $this->databaseTool->loadFixtures($fixtures);
 
-        // Load data from database
+        // Load data from database.
         /** @var User $user1 */
         $user1 = $this->userRepository->findOneBy(['id' => 1]);
 
@@ -141,7 +136,8 @@ class ConfigTest extends KernelTestCase
 
         sleep(2);
 
-        $this->clearEntityManager();
+        // Cache is up-to-date, but it won't be used since its usage is disabled.
+        $this->assertTrue($this->sqliteDatabaseBackup->isBackupActual());
 
         // Reload the fixtures.
         $this->databaseTool->loadFixtures($fixtures);
@@ -149,11 +145,13 @@ class ConfigTest extends KernelTestCase
         /** @var User $user1 */
         $user1 = $this->userRepository->findOneBy(['id' => 1]);
 
-        // The salt are not the same because cache were not used
+        // The salt are not the same because the cache was not used.
         $this->assertNotSame($user1Salt, $user1->getSalt());
 
         // Enable the cache again
         $this->databaseTool->setDatabaseCacheEnabled(true);
+
+        $this->assertTrue($this->databaseTool->isDatabaseCacheEnabled());
     }
 
     /**
@@ -191,7 +189,7 @@ class ConfigTest extends KernelTestCase
 
         sleep(2);
 
-        $this->clearEntityManager();
+        $this->assertTrue($this->sqliteDatabaseBackup->isBackupActual());
 
         // Reload the fixtures.
         $this->databaseTool->loadFixtures($fixtures);
@@ -217,10 +215,10 @@ class ConfigTest extends KernelTestCase
 
         sleep(2);
 
-        $this->clearEntityManager();
-
         // Update the filemtime of the fixture file used as a dependency.
         touch($dependentFixtureFilePath);
+
+        $this->assertFalse($this->sqliteDatabaseBackup->isBackupActual());
 
         $this->databaseTool->loadFixtures($fixtures);
 
@@ -247,11 +245,6 @@ class ConfigTest extends KernelTestCase
     protected static function getKernelClass(): string
     {
         return AppConfigKernel::class;
-    }
-
-    protected function clearEntityManager(): void
-    {
-        $this->entityManager->clear();
     }
 
     protected function tearDown(): void


### PR DESCRIPTION
Follow-up of:

- #316