### PR TITLE
change parent classe for clear deprecation

### DIFF
--- a/src/DependencyInjection/LiipTestFixturesExtension.php
+++ b/src/DependencyInjection/LiipTestFixturesExtension.php
@@ -16,7 +16,7 @@ namespace Liip\TestFixturesBundle\DependencyInjection;
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
-use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\Extension\Extension;
 
 class LiipTestFixturesExtension extends Extension
 {

--- a/src/DependencyInjection/LiipTestFixturesExtension.php
+++ b/src/DependencyInjection/LiipTestFixturesExtension.php
@@ -15,8 +15,8 @@ namespace Liip\TestFixturesBundle\DependencyInjection;
 
 use Symfony\Component\Config\FileLocator;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
-use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 use Symfony\Component\DependencyInjection\Extension\Extension;
+use Symfony\Component\DependencyInjection\Loader\XmlFileLoader;
 
 class LiipTestFixturesExtension extends Extension
 {


### PR DESCRIPTION
Change the parent class for prevent deprecation since symfony 7.1 : 

The "Symfony\Component\HttpKernel\DependencyInjection\Extension" class is considered internal since Symfony 7.1, to be deprecated in 8.1; use Symfony\Component\DependencyInjection\Extension\Extension instead. It may change without further notice. You should not use it from "Liip\TestFixturesBundle\DependencyInjection\LiipTestFixturesExtension".