### PR TITLE
[3.x] Drop dependency to doctrine/common

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,6 @@
     ],
     "require": {
         "php": "^8.1",
-        "doctrine/common": "^2.13 || ^3.0",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
         "symfony/event-dispatcher": "^5.4 || ^6.3 || ^7.0",


### PR DESCRIPTION
Nothing in this bundle uses code from that package, so there's no point in pulling it in (especially as other Doctrine projects are moving away from using it).