### PR TITLE
fix: cache reference repository

### DIFF
--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -27,21 +27,29 @@ use Liip\TestFixturesBundle\Event\PostFixtureBackupRestoreEvent;
 use Liip\TestFixturesBundle\Event\PreFixtureBackupRestoreEvent;
 use Liip\TestFixturesBundle\Event\ReferenceSaveEvent;
 use Liip\TestFixturesBundle\LiipTestFixturesEvents;
+use Symfony\Contracts\Service\ResetInterface;
 
 /**
  * @author Aleksey Tupichenkov <alekseytupichenkov@gmail.com>
  */
-class ORMDatabaseTool extends AbstractDbalDatabaseTool
+class ORMDatabaseTool extends AbstractDbalDatabaseTool implements ResetInterface
 {
     /**
      * @var EntityManager
      */
     protected $om;
 
+    private ?ProxyReferenceRepository $referenceRepository = null;
+
     /**
      * @var bool
      */
     private $shouldEnableForeignKeyChecks = false;
+
+    public function reset()
+    {
+        $this->referenceRepository = null;
+    }
 
     public function getType(): string
     {
@@ -50,7 +58,11 @@ class ORMDatabaseTool extends AbstractDbalDatabaseTool
 
     public function loadFixtures(array $classNames = [], bool $append = false): AbstractExecutor
     {
-        $referenceRepository = new ProxyReferenceRepository($this->om);
+        if (null === $this->referenceRepository || false === $append) {
+            $this->referenceRepository = new ProxyReferenceRepository($this->om);
+        }
+
+        $referenceRepository = $this->referenceRepository;
 
         /** @var Configuration $config */
         $config = $this->om->getConfiguration();

--- a/tests/AppConfigSqliteUrl/config.yml
+++ b/tests/AppConfigSqliteUrl/config.yml
@@ -2,5 +2,5 @@
 
 doctrine:
     dbal:
-        url: 'sqlite:///%kernel.project_dir%/var/app.db'
+        url: 'sqlite:///%kernel.cache_dir%/test.db'
 

--- a/tests/Test/ConfigMysqlCacheDbTest.php
+++ b/tests/Test/ConfigMysqlCacheDbTest.php
@@ -118,7 +118,6 @@ class ConfigMysqlCacheDbTest extends ConfigMysqlTest
      */
     public function testLoadFixturesCheckReferences(): void
     {
-        $this->markTestSkipped('This test is broken right now.');
         $referenceRepository = $this->databaseTool->loadFixtures([
             'Liip\Acme\Tests\App\DataFixtures\ORM\LoadUserData',
         ])->getReferenceRepository();

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -140,10 +140,12 @@ class ConfigMysqlTest extends KernelTestCase
             'Liip\Acme\Tests\App\DataFixtures\ORM\LoadUserData',
         ]);
 
-        $this->databaseTool->loadFixtures(
+        $referenceRepository = $this->databaseTool->loadFixtures(
             ['Liip\Acme\Tests\App\DataFixtures\ORM\LoadSecondUserData'],
             true
-        );
+        )->getReferenceRepository();
+
+        $this->assertCount(2, $referenceRepository->getReferences());
 
         // Load data from database
         $users = $this->userRepository->findAll();


### PR DESCRIPTION
Fix bug from the issue #331.

I added caching of the reference repository to save references after second calling `loadFixtures` method with the `$append` flag.