### PR TITLE
feat: drop support for symfony < 6.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -20,21 +20,18 @@ jobs:
             # Use "update" instead of "install" since it allows using the "--prefer-lowest" option
             composer-flags: "update --prefer-lowest"
           - php-version: 8.1
-            # add a specific job to test ^5.4 for all Symfony packages
-            symfony-version: "^5.4"
-            # `theofidry/alice-data-fixtures:1.6.0` and `doctrine/dbal:^4.0` cause issues:
-            # Error: Call to undefined method Doctrine\DBAL\Connection::exec()
-            composer-flags: "require doctrine/dbal:^3.0"
+            # add a specific job to test ^6.4 for all Symfony packages
+            symfony-version: "^6.4"
           - php-version: 8.2
             symfony-version: "^6.4"
             # add a specific job to test mysqldump from MariaDB
             mysql-client: "mariadb-client"
           - php-version: 8.2
-            symfony-version: "^7.2"
+            symfony-version: "^7.3"
           - php-version: 8.3
-            symfony-version: "^7.2"
+            symfony-version: "^7.3"
           - php-version: 8.4
-            symfony-version: "^7.2"
+            symfony-version: "^7.3"
 
     services:
       mariadb:

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
         "php": "^8.1",
         "doctrine/persistence": "^1.3.3 || ^2.0 || ^3.0 || ^4.0",
         "symfony/deprecation-contracts": "^2.1 || ^3.0",
-        "symfony/event-dispatcher": "^5.4 || ^6.3 || ^7.0",
+        "symfony/event-dispatcher": "^6.4 || ^7.0",
         "symfony/event-dispatcher-contracts": "^1 || ^2 || ^3",
-        "symfony/framework-bundle": "^5.4 || ^6.3 || ^7.0",
-        "symfony/yaml": "^5.4 || ^6.3 || ^7.0"
+        "symfony/framework-bundle": "^6.4 || ^7.0",
+        "symfony/yaml": "^6.4 || ^7.0"
     },
     "require-dev": {
         "doctrine/data-fixtures": "^1.7 || ^2.0.1",
@@ -32,8 +32,8 @@
         "doctrine/mongodb-odm": "^2.5",
         "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
         "phpunit/phpunit": "^10.5.11 || ^11.0.4",
-        "symfony/doctrine-bridge": "^5.4 || ^6.3 || ^7.0",
-        "symfony/monolog-bridge": "^5.4 || ^6.3 || ^7.0",
+        "symfony/doctrine-bridge": "^6.4 || ^7.0",
+        "symfony/monolog-bridge": "^6.4 || ^7.0",
         "symfony/monolog-bundle": "^3.2",
         "theofidry/alice-data-fixtures": "^1.5.2"
     },

--- a/src/Event/FixtureEvent.php
+++ b/src/Event/FixtureEvent.php
@@ -16,13 +16,7 @@ namespace Liip\TestFixturesBundle\Event;
 // Compatibility layer to use Contract if Symfony\Contracts\EventDispatcher\Event is not available
 use Symfony\Contracts\EventDispatcher\Event;
 
-if (class_exists('\Symfony\Component\EventDispatcher\Event')) {
-    // Symfony < 5.0
-    class FixtureEvent extends \Symfony\Component\EventDispatcher\Event
-    {
-    }
-} else {
-    class FixtureEvent extends Event
-    {
-    }
+class FixtureEvent extends Event
+{
 }
+


### PR DESCRIPTION
Please see https://github.com/liip/LiipTestFixturesBundle/pull/341
and https://github.com/doctrine/DoctrineMongoDBBundle/issues/895#issuecomment-2974672222

CI fails in part of deprecation message for. should be handled in a seperate PR in my point of view.
reportFieldsWhereDeclared