### PR TITLE
feat: add another entity to tests

### DIFF
--- a/tests/App/DataFixtures/ORM/LoadDependentUserData.php
+++ b/tests/App/DataFixtures/ORM/LoadDependentUserData.php
@@ -43,6 +43,7 @@ class LoadDependentUserData extends AbstractFixture implements DependentFixtureI
     {
         return [
             'Liip\Acme\Tests\App\DataFixtures\ORM\LoadUserData',
+            'Liip\Acme\Tests\App\DataFixtures\ORM\LoadSettingData',
         ];
     }
 }

--- a/tests/App/DataFixtures/ORM/LoadSettingData.php
+++ b/tests/App/DataFixtures/ORM/LoadSettingData.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/TestFixturesBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\App\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Persistence\ObjectManager;
+use Liip\Acme\Tests\App\Entity\Setting;
+
+class LoadSettingData extends AbstractFixture
+{
+    public function load(ObjectManager $manager): void
+    {
+        $setting1 = new Setting('name', 'value');
+
+        $manager->persist($setting1);
+
+        $setting2 = new Setting('name_foo', 'value_bar');
+
+        $manager->persist($setting2);
+
+        $manager->flush();
+    }
+}

--- a/tests/App/Entity/Setting.php
+++ b/tests/App/Entity/Setting.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * This file is part of the Liip/TestFixturesBundle
+ *
+ * (c) Lukas Kahwe Smith <smith@pooteeweet.org>
+ *
+ * This source file is subject to the MIT license that is bundled
+ * with this source code in the file LICENSE.
+ */
+
+namespace Liip\Acme\Tests\App\Entity;
+
+use Doctrine\DBAL\Types\Types;
+use Doctrine\ORM\Mapping as ORM;
+
+#[ORM\Entity]
+#[ORM\Table(name: 'liip_settings')]
+class Setting
+{
+    #[ORM\Id]
+    #[ORM\Column(type: Types::INTEGER)]
+    #[ORM\GeneratedValue(strategy: 'AUTO')]
+    private ?int $id = null;
+
+    public function __construct(
+        #[ORM\Column]
+        private string $name,
+        #[ORM\Column]
+        private string $value,
+    ) {
+    }
+
+    public function setId(int $id): self
+    {
+        $this->id = $id;
+
+        return $this;
+    }
+
+    public function getId(): int
+    {
+        return $this->id;
+    }
+
+    public function getName(): string
+    {
+        return $this->name;
+    }
+
+    public function getValue(): string
+    {
+        return $this->value;
+    }
+}

--- a/tests/Test/ConfigMysqlTest.php
+++ b/tests/Test/ConfigMysqlTest.php
@@ -15,6 +15,7 @@ namespace Liip\Acme\Tests\Test;
 
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\Persistence\ObjectRepository;
+use Liip\Acme\Tests\App\Entity\Setting;
 use Liip\Acme\Tests\App\Entity\User;
 use Liip\Acme\Tests\AppConfigMysql\AppConfigMysqlKernel;
 use Liip\TestFixturesBundle\Services\DatabaseToolCollection;
@@ -44,6 +45,9 @@ class ConfigMysqlTest extends KernelTestCase
     /** @var ObjectRepository */
     protected $userRepository;
 
+    /** @var ObjectRepository */
+    protected $settingRepository;
+
     /** @var AbstractDatabaseTool */
     protected $databaseTool;
 
@@ -57,6 +61,10 @@ class ConfigMysqlTest extends KernelTestCase
 
         $this->userRepository = $testContainer->get('doctrine')
             ->getRepository(User::class)
+        ;
+
+        $this->settingRepository = $testContainer->get('doctrine')
+            ->getRepository(Setting::class)
         ;
 
         $this->databaseTool = $testContainer->get(DatabaseToolCollection::class)->get();
@@ -345,6 +353,9 @@ class ConfigMysqlTest extends KernelTestCase
 
     /**
      * Load fixture which has a dependency.
+     *
+     * @group mysql
+     * @group pgsql
      */
     public function testLoadDependentFixtures(): void
     {
@@ -363,6 +374,14 @@ class ConfigMysqlTest extends KernelTestCase
         $this->assertCount(
             4,
             $users
+        );
+
+        // Settings have been loaded too
+        $settings = $this->settingRepository->findAll();
+
+        $this->assertCount(
+            2,
+            $settings
         );
     }
 

--- a/tests/Test/ConfigPgsqlTest.php
+++ b/tests/Test/ConfigPgsqlTest.php
@@ -37,35 +37,12 @@ use PHPUnit\Framework\Attributes\PreserveGlobalState;
  * @IgnoreAnnotation("group")
  *
  * @internal
+ *
+ * @group pgsql
  */
 #[PreserveGlobalState(false)]
 class ConfigPgsqlTest extends ConfigMysqlTest
 {
-    /**
-     * Load fixture which has a dependency.
-     *
-     * @group pgsql
-     */
-    public function testLoadDependentFixtures(): void
-    {
-        $fixtures = $this->databaseTool->loadFixtures([
-            'Liip\Acme\Tests\App\DataFixtures\ORM\LoadDependentUserData',
-        ]);
-
-        $this->assertInstanceOf(
-            'Doctrine\Common\DataFixtures\Executor\ORMExecutor',
-            $fixtures
-        );
-
-        $users = $this->userRepository->findAll();
-
-        // The two files with fixtures have been loaded, there are 4 users.
-        $this->assertCount(
-            4,
-            $users
-        );
-    }
-
     /**
      * @group pgsql
      */


### PR DESCRIPTION
The following code was never run during tests because they loaded only one type of entity:

https://github.com/liip/LiipTestFixturesBundle/blob/c9f59560bb8a43d862141a8125a071abe13a9afb/src/Services/DatabaseTools/AbstractDatabaseTool.php#L251

So with a second entity, `usort` will be ran and it should prevent future regressions.