### PR TITLE
feat: allow PHPUnit 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "doctrine/orm": "^2.14 || ^3.1.0",
         "doctrine/mongodb-odm": "^2.5",
         "monolog/monolog": "^1.25.1 || ^2.0 || ^3.0",
-        "phpunit/phpunit": "^10.5.11 || ^11.0.4",
+        "phpunit/phpunit": "^10.5.11 || ^11.0.4 || ^12.0.0",
         "symfony/doctrine-bridge": "^5.4 || ^6.3 || ^7.0",
         "symfony/monolog-bridge": "^5.4 || ^6.3 || ^7.0",
         "symfony/monolog-bundle": "^3.2",


### PR DESCRIPTION
PHPUnit 12 requires PHP 8.3+ : https://phpunit.de/supported-versions.html

So the other jobs with PHP < 8.3 will use previous versions of PHPUnit and the CI will test different versions.