### PR TITLE
Fix MySQL/MariaDB platform detection for DBAL 4 compatibility

### DIFF
--- a/src/Services/DatabaseTools/ORMDatabaseTool.php
+++ b/src/Services/DatabaseTools/ORMDatabaseTool.php
@@ -18,7 +18,6 @@ use Doctrine\Common\DataFixtures\Executor\ORMExecutor;
 use Doctrine\Common\DataFixtures\ProxyReferenceRepository;
 use Doctrine\Common\DataFixtures\Purger\ORMPurger;
 use Doctrine\DBAL\DriverManager;
-use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\ORM\Configuration;
 use Doctrine\ORM\EntityManager;
 use Doctrine\ORM\Tools\SchemaTool;
@@ -249,6 +248,6 @@ class ORMDatabaseTool extends AbstractDbalDatabaseTool implements ResetInterface
 
     private function isMysql(): bool
     {
-        return $this->connection->getDatabasePlatform() instanceof MySQLPlatform;
+        return 'mysql' === $this->getPlatformName();
     }
 }


### PR DESCRIPTION
## Summary

This PR updates the MySQL platform detection logic in `ORMDatabaseTool` to ensure compatibility with **Doctrine DBAL 4**.

## The Issue

In Doctrine DBAL 4, `MariaDBPlatform` no longer extends `MySQLPlatform` but extends `AbstractMySQLPlatform` directly. This caused the `instanceof MySQLPlatform` check in `isMysql()` to return `false` on MariaDB setups, preventing the bundle from correctly disabling/enabling foreign key checks when purging the database with truncate.

## The Fix

I've updated `isMysql()` to use the already existing `getPlatformName()` method from `AbstractDbalDatabaseTool`.
This method already has the check for the newer `AbstractMySQLPlatform` which is the highest common ancestor of both `MySQLPlatform` and `MariaDBPlatform`.

This ensures that the platform check `isMysql()` inside `disableForeignKeyChecksIfApplicable` and `enableForeignKeyChecksIfApplicable` returns true and foreign key checks are disabled/enabled correctly when called using a MariaDB database with DBAL 4.

## Testing

- All tests passed.